### PR TITLE
feat: Implement escalation timer

### DIFF
--- a/src/core/EscalationTimer.ts
+++ b/src/core/EscalationTimer.ts
@@ -194,9 +194,9 @@ export class EscalationTimer {
    * Cancel all active timers.
    */
   private cancelAllTimers(): void {
-    for (const [alertId, handle] of this.activeTimers) {
+    for (const handle of this.activeTimers.values()) {
       this.timerFns.clearTimeout(handle)
-      this.activeTimers.delete(alertId)
     }
+    this.activeTimers.clear()
   }
 }

--- a/test/core/EscalationTimer.test.ts
+++ b/test/core/EscalationTimer.test.ts
@@ -4,7 +4,7 @@ import {
   type EscalationEvent,
   type EscalationTimerConfig
 } from '../../src/core/EscalationTimer.js'
-import { FakeTimerFunctions } from '../../src/test/FakeTimerFunctions.js'
+import { FakeTimerFunctions } from '../helpers/FakeTimerFunctions.js'
 
 describe('EscalationTimer', () => {
   let timer: EscalationTimer
@@ -376,6 +376,22 @@ describe('EscalationTimer', () => {
       expect(escalationEvents).toHaveLength(1)
     })
 
+    it('should treat negative timeout as immediate escalation', () => {
+      // Negative values result in immediate timer expiration (same as setTimeout behavior)
+      timer = new EscalationTimer(
+        { enabled: true, timeoutSeconds: -10 },
+        (event) => escalationEvents.push(event),
+        fakeTimers
+      )
+
+      timer.startTimer('alert-1', 'warning')
+
+      // Advance by 0 to process timers that have already expired
+      fakeTimers.advanceTime(0)
+
+      expect(escalationEvents).toHaveLength(1)
+    })
+
     it('should use default timer functions when not provided', () => {
       // This test just verifies the constructor accepts undefined timerFunctions
       const timerWithDefaults = new EscalationTimer(
@@ -388,6 +404,27 @@ describe('EscalationTimer', () => {
       expect(() => {
         timerWithDefaults.stop()
       }).not.toThrow()
+    })
+
+    it('should propagate callback exceptions to caller', () => {
+      const error = new Error('Callback failed')
+      timer = new EscalationTimer(
+        defaultConfig,
+        () => {
+          throw error
+        },
+        fakeTimers
+      )
+
+      timer.startTimer('alert-1', 'warning')
+
+      // Exception should propagate - caller is responsible for handling
+      expect(() => {
+        fakeTimers.advanceTime(300 * 1000)
+      }).toThrow(error)
+
+      // Timer should still be removed from tracking (cleanup happens before callback)
+      expect(timer.hasTimer('alert-1')).toBe(false)
     })
   })
 })

--- a/test/helpers/FakeTimerFunctions.ts
+++ b/test/helpers/FakeTimerFunctions.ts
@@ -4,7 +4,7 @@
  * Provides controllable time advancement for deterministic tests.
  */
 
-import type { TimerFunctions, TimerHandle } from '../core/EscalationTimer.js'
+import type { TimerFunctions, TimerHandle } from '../../src/core/EscalationTimer.js'
 
 interface PendingTimer {
   callback: () => void


### PR DESCRIPTION
## Summary

- Implement EscalationTimer that tracks unacknowledged Warning alerts
- Escalate Warning → Alarm after configurable timeout (default 300s)
- Add FakeTimerFunctions test utility for deterministic timer testing
- 40 comprehensive tests covering all functionality

## Features

- Configurable timeout via `escalation.warningToAlarm.timeoutSeconds`
- Enable/disable escalation via `escalation.warningToAlarm.enabled`
- Timer cancellation on acknowledgment or clearing
- Multiple concurrent timers for independent alerts
- Clean `stop()` for plugin shutdown
- Injectable timer functions for testing

## Test plan

- [x] Timer starts only for warning priority (40 tests pass)
- [x] Escalation fires after configured timeout
- [x] Timer cancellation prevents escalation
- [x] Multiple concurrent timers work independently
- [x] `stop()` cleans up all timers
- [x] Configuration updates work correctly

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)