### PR TITLE
chore(ci): add label triggers for version bump check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ name: PR Checks
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Add `labeled`/`unlabeled` event types to `pull_request` trigger in `pr.yml`
- Enables the `no-version-bump` label escape hatch for the version bump enforcement check added in hatlabs/shared-workflows#12

## Context

The shared-workflows `pr-checks.yml` now includes a `version-bump-check` job. For the `no-version-bump` label to re-trigger the workflow (allowing the check to pass after labeling), the caller workflow needs to include `labeled`/`unlabeled` in its event types.

## Test plan

- [ ] Verify PR checks still run on push (synchronize)
- [ ] Verify PR checks run when labels are added/removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)