### PR TITLE
feat: implement history logging for alert lifecycle audit trail

### DIFF
--- a/src/core/AlertManager.ts
+++ b/src/core/AlertManager.ts
@@ -144,8 +144,8 @@ export class AlertManager extends EventEmitter {
   async loadFromStore(): Promise<void> {
     // Prune old history entries on startup
     if (this.historyStore && this.config.retentionDays !== undefined) {
-      this.historyStore.prune(this.config.retentionDays).catch(() => {
-        // Fire-and-forget: pruning failure is non-critical
+      this.historyStore.prune(this.config.retentionDays).catch((err: unknown) => {
+        console.warn('History pruning failed:', err)
       })
     }
 
@@ -187,6 +187,8 @@ export class AlertManager extends EventEmitter {
 
           // Persist the unsilenced state
           await this.store.update(unsilenced)
+
+          this.logHistory('unsilence', unsilenced)
 
           // Emit event for consistency with manual unsilence path
           this.emitEvent('unsilenced', unsilenced)
@@ -258,7 +260,8 @@ export class AlertManager extends EventEmitter {
       await this.removeAlert(alertId, alert)
       this.logHistory('clear', alert, {
         userId,
-        previousState: result.previousState
+        previousState: result.previousState,
+        newState: 'cleared'
       })
       this.emitEvent('cleared', alert, result.previousState)
     } else if (result.alert) {
@@ -361,6 +364,9 @@ export class AlertManager extends EventEmitter {
       }
 
       this.startSilenceExpirationTimer(alert.id, duration)
+      this.logHistory('silence', silenced, {
+        details: { silencedUntil: silenced.silencedUntil }
+      })
       this.emitEvent('silenced', silenced)
     }
   }
@@ -381,7 +387,10 @@ export class AlertManager extends EventEmitter {
 
     if (result.cleared) {
       await this.removeAlert(alertId, alert)
-      this.logHistory('clear', alert, { previousState: result.previousState })
+      this.logHistory('clear', alert, {
+        previousState: result.previousState,
+        newState: 'cleared'
+      })
       this.emitEvent('cleared', alert, result.previousState)
     } else if (result.alert) {
       this.alerts.set(alertId, result.alert)
@@ -628,6 +637,13 @@ export class AlertManager extends EventEmitter {
       await this.store.update(updated)
     }
 
+    if (newPriority !== existing.priority) {
+      this.logHistory('escalate', updated, {
+        previousPriority: existing.priority,
+        newPriority
+      })
+    }
+
     this.emitEvent('updated', updated)
 
     return updated
@@ -692,8 +708,8 @@ export class AlertManager extends EventEmitter {
         newPriority: extra?.newPriority,
         details: extra?.details
       })
-      .catch(() => {
-        // Fire-and-forget: history logging failure must not affect alert operations
+      .catch((err: unknown) => {
+        console.warn('History logging failed:', err)
       })
   }
 

--- a/src/store/HistoryStore.ts
+++ b/src/store/HistoryStore.ts
@@ -6,9 +6,12 @@
  *
  * Opens its own connection to the same database file as AlertStore.
  * WAL mode allows concurrent read/write access across connections.
+ *
+ * All timestamps are stored and compared as UTC ISO 8601 strings
+ * (ending in 'Z'), which sort lexicographically in chronological order.
  */
 
-import { DatabaseSync } from 'node:sqlite'
+import { DatabaseSync, type StatementSync } from 'node:sqlite'
 import * as fs from 'fs'
 import * as path from 'path'
 import type {
@@ -36,6 +39,8 @@ interface HistoryRow {
 export class HistoryStore implements IHistoryStore {
   private dbPath: string
   private db: DatabaseSync | null = null
+  private insertStmt: StatementSync | null = null
+  private pruneStmt: StatementSync | null = null
 
   constructor(dbPath: string) {
     this.dbPath = dbPath
@@ -76,7 +81,17 @@ export class HistoryStore implements IHistoryStore {
       db.exec(`
         CREATE INDEX IF NOT EXISTS idx_history_alert_id ON history(alert_id);
         CREATE INDEX IF NOT EXISTS idx_history_timestamp ON history(timestamp);
+        CREATE INDEX IF NOT EXISTS idx_history_event_type ON history(event_type);
       `)
+
+      // Cache prepared statements for fixed queries
+      this.insertStmt = db.prepare(`
+        INSERT INTO history (
+          id, alert_id, event_type, timestamp, user_id,
+          previous_state, new_state, previous_priority, new_priority, details
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      this.pruneStmt = db.prepare('DELETE FROM history WHERE timestamp < ?')
 
       return Promise.resolve()
     } catch (error) {
@@ -85,6 +100,8 @@ export class HistoryStore implements IHistoryStore {
   }
 
   close(): Promise<void> {
+    this.insertStmt = null
+    this.pruneStmt = null
     if (this.db) {
       this.db.close()
       this.db = null
@@ -94,17 +111,10 @@ export class HistoryStore implements IHistoryStore {
 
   log(entry: Omit<HistoryEntry, 'id'>): Promise<void> {
     try {
-      const db = this.getDb()
+      this.getDb() // Ensure initialized
       const id = crypto.randomUUID()
 
-      const stmt = db.prepare(`
-        INSERT INTO history (
-          id, alert_id, event_type, timestamp, user_id,
-          previous_state, new_state, previous_priority, new_priority, details
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `)
-
-      stmt.run(
+      this.getInsertStmt().run(
         id,
         entry.alertId,
         entry.eventType,
@@ -134,6 +144,12 @@ export class HistoryStore implements IHistoryStore {
         whereSql += ' AND alert_id = ?'
         params.push(query.alertId)
       }
+      if (query.eventType) {
+        const types = Array.isArray(query.eventType) ? query.eventType : [query.eventType]
+        const placeholders = types.map(() => '?').join(', ')
+        whereSql += ` AND event_type IN (${placeholders})`
+        params.push(...types)
+      }
       if (query.from) {
         whereSql += ' AND timestamp >= ?'
         params.push(query.from)
@@ -155,10 +171,11 @@ export class HistoryStore implements IHistoryStore {
       if (query.limit !== undefined) {
         dataSql += ' LIMIT ?'
         dataParams.push(query.limit)
-      }
-      if (query.offset !== undefined) {
-        dataSql += ' OFFSET ?'
-        dataParams.push(query.offset)
+        // Only apply offset when limit is present (OFFSET without LIMIT is undefined in standard SQL)
+        if (query.offset !== undefined) {
+          dataSql += ' OFFSET ?'
+          dataParams.push(query.offset)
+        }
       }
 
       const dataStmt = db.prepare(dataSql)
@@ -174,11 +191,15 @@ export class HistoryStore implements IHistoryStore {
 
   prune(olderThanDays: number): Promise<number> {
     try {
-      const db = this.getDb()
-      const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000).toISOString()
+      if (olderThanDays < 1) {
+        return Promise.reject(
+          new Error(`retentionDays must be >= 1 (got ${String(olderThanDays)})`)
+        )
+      }
 
-      const stmt = db.prepare('DELETE FROM history WHERE timestamp < ?')
-      const result = stmt.run(cutoff)
+      this.getDb() // Ensure initialized
+      const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000).toISOString()
+      const result = this.getPruneStmt().run(cutoff)
 
       return Promise.resolve(Number(result.changes))
     } catch (error) {
@@ -191,6 +212,20 @@ export class HistoryStore implements IHistoryStore {
       throw new Error('HistoryStore not initialized. Call initialize() first.')
     }
     return this.db
+  }
+
+  private getInsertStmt(): StatementSync {
+    if (!this.insertStmt) {
+      throw new Error('HistoryStore not initialized. Call initialize() first.')
+    }
+    return this.insertStmt
+  }
+
+  private getPruneStmt(): StatementSync {
+    if (!this.pruneStmt) {
+      throw new Error('HistoryStore not initialized. Call initialize() first.')
+    }
+    return this.pruneStmt
   }
 
   private rowToHistoryEntry(row: HistoryRow): HistoryEntry {

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,19 +196,22 @@ export interface AlertFilter {
  * Query parameters for retrieving alert history.
  */
 export interface HistoryQuery {
-  /** Start of date range (ISO timestamp) */
+  /** Start of date range (UTC ISO 8601 timestamp ending in Z) */
   from?: string
 
-  /** End of date range (ISO timestamp) */
+  /** End of date range (UTC ISO 8601 timestamp ending in Z) */
   to?: string
 
   /** Filter by specific alert ID */
   alertId?: string
 
+  /** Filter by event type(s) */
+  eventType?: HistoryEventType | HistoryEventType[]
+
   /** Maximum number of entries to return */
   limit?: number
 
-  /** Number of entries to skip (for pagination) */
+  /** Number of entries to skip (for pagination, requires limit) */
   offset?: number
 }
 

--- a/test/core/AlertManager.test.ts
+++ b/test/core/AlertManager.test.ts
@@ -1561,7 +1561,7 @@ describe('AlertManager', () => {
       expect(historyStore.entries[0].newState).toBe('acknowledged')
     })
 
-    it('should log clear event when RTN alert is acknowledged', async () => {
+    it('should log clear event with newState cleared when RTN alert is acknowledged', async () => {
       const alert = await manager.raiseAlert({
         sourceId: 'test-source',
         priority: 'alarm',
@@ -1574,6 +1574,7 @@ describe('AlertManager', () => {
 
       expect(historyStore.entries).toHaveLength(1)
       expect(historyStore.entries[0].eventType).toBe('clear')
+      expect(historyStore.entries[0].newState).toBe('cleared')
     })
 
     it('should log silence event', async () => {
@@ -1606,7 +1607,7 @@ describe('AlertManager', () => {
       expect(historyStore.entries[0].eventType).toBe('unsilence')
     })
 
-    it('should log clear event on clearCondition (when alert is removed)', async () => {
+    it('should log clear event with newState cleared on clearCondition (when alert is removed)', async () => {
       const alert = await manager.raiseAlert({
         sourceId: 'test-source',
         priority: 'alarm',
@@ -1619,6 +1620,7 @@ describe('AlertManager', () => {
 
       expect(historyStore.entries).toHaveLength(1)
       expect(historyStore.entries[0].eventType).toBe('clear')
+      expect(historyStore.entries[0].newState).toBe('cleared')
     })
 
     it('should log clear event on clearCondition (RTN transition)', async () => {
@@ -1670,6 +1672,80 @@ describe('AlertManager', () => {
 
       expect(historyStore.entries).toHaveLength(1)
       expect(historyStore.entries[0].eventType).toBe('unsilence')
+    })
+
+    it('should log silence events for each alert in silenceAll', async () => {
+      await manager.raiseAlert({
+        sourceId: 'test-source',
+        priority: 'alarm',
+        message: 'Alert 1'
+      })
+      await manager.raiseAlert({
+        sourceId: 'test-source',
+        priority: 'warning',
+        message: 'Alert 2'
+      })
+      historyStore.entries = []
+
+      await manager.silenceAll()
+
+      const silenceEntries = historyStore.entries.filter((e) => e.eventType === 'silence')
+      expect(silenceEntries).toHaveLength(2)
+      expect(silenceEntries.every((e) => e.details?.silencedUntil)).toBe(true)
+    })
+
+    it('should log escalate event when re-raising with higher priority', async () => {
+      await manager.raiseAlert({
+        sourceId: 'test-source',
+        priority: 'warning',
+        message: 'Test alert'
+      })
+      historyStore.entries = []
+
+      await manager.raiseAlert({
+        sourceId: 'test-source',
+        priority: 'alarm',
+        message: 'Test alert'
+      })
+
+      const escalateEntries = historyStore.entries.filter((e) => e.eventType === 'escalate')
+      expect(escalateEntries).toHaveLength(1)
+      expect(escalateEntries[0].previousPriority).toBe('warning')
+      expect(escalateEntries[0].newPriority).toBe('alarm')
+    })
+
+    it('should log unsilence event for expired silence on loadFromStore', async () => {
+      // Seed a silenced alert with expired silencedUntil directly into the store
+      const silencedAlert: Alert = {
+        id: 'expired-silence-1',
+        sourceId: 'test-source',
+        priority: 'alarm',
+        state: 'unacknowledged',
+        condition: true,
+        latching: false,
+        silenced: true,
+        silencedUntil: new Date(Date.now() - 1000).toISOString(),
+        message: 'Test alert',
+        raisedAt: new Date(Date.now() - 60000).toISOString(),
+        sourceOnline: true,
+        lastSourceUpdate: new Date().toISOString(),
+        stale: false
+      }
+      await store.save(silencedAlert)
+
+      // Create a new manager and load from store
+      const newHistoryStore = new MockHistoryStore()
+      const newManager = new AlertManager(
+        { ...defaultConfig, retentionDays: 90 },
+        fakeTimers,
+        store,
+        newHistoryStore
+      )
+      await newManager.loadFromStore()
+
+      const unsilenceEntries = newHistoryStore.entries.filter((e) => e.eventType === 'unsilence')
+      expect(unsilenceEntries).toHaveLength(1)
+      newManager.stop()
     })
 
     it('should not affect alert operations when history logging fails', async () => {

--- a/test/store/HistoryStore.test.ts
+++ b/test/store/HistoryStore.test.ts
@@ -214,6 +214,39 @@ describe('HistoryStore', () => {
       expect(result.entries).toHaveLength(1)
       expect(result.total).toBe(3)
     })
+
+    it('should filter by single eventType', async () => {
+      await store.log(createTestEntry({ eventType: 'raise' }))
+      await store.log(createTestEntry({ eventType: 'acknowledge' }))
+      await store.log(createTestEntry({ eventType: 'escalate' }))
+
+      const result = await store.query({ eventType: 'escalate' })
+      expect(result.entries).toHaveLength(1)
+      expect(result.entries[0].eventType).toBe('escalate')
+      expect(result.total).toBe(1)
+    })
+
+    it('should filter by multiple eventTypes', async () => {
+      await store.log(createTestEntry({ eventType: 'raise' }))
+      await store.log(createTestEntry({ eventType: 'acknowledge' }))
+      await store.log(createTestEntry({ eventType: 'escalate' }))
+      await store.log(createTestEntry({ eventType: 'clear' }))
+
+      const result = await store.query({ eventType: ['raise', 'clear'] })
+      expect(result.entries).toHaveLength(2)
+      expect(result.total).toBe(2)
+    })
+
+    it('should ignore offset when limit is not set', async () => {
+      for (let i = 0; i < 5; i++) {
+        await store.log(createTestEntry({ alertId: `a${String(i)}` }))
+      }
+
+      // offset without limit should return all entries (offset ignored)
+      const result = await store.query({ offset: 2 })
+      expect(result.entries).toHaveLength(5)
+      expect(result.total).toBe(5)
+    })
   })
 
   describe('prune', () => {
@@ -250,6 +283,15 @@ describe('HistoryStore', () => {
     it('should return 0 when nothing to prune', async () => {
       const deleted = await store.prune(90)
       expect(deleted).toBe(0)
+    })
+
+    it('should reject olderThanDays of 0', async () => {
+      await store.log(createTestEntry())
+      await expect(store.prune(0)).rejects.toThrow('retentionDays must be >= 1')
+    })
+
+    it('should reject negative olderThanDays', async () => {
+      await expect(store.prune(-5)).rejects.toThrow('retentionDays must be >= 1')
     })
   })
 


### PR DESCRIPTION
## Summary

- Add `IHistoryStore` interface and `HistoryStore` SQLite implementation for persisting alert lifecycle events
- Integrate fire-and-forget history logging into `AlertManager` at each lifecycle point (raise, acknowledge, silence, unsilence, clear, escalate)
- Prune old history entries on startup based on `retentionDays` config

Closes #12

## Test plan

- [x] `npm test` — 301 tests pass (20 new HistoryStore tests + 12 new AlertManager history tests)
- [x] `npm run lint` — no lint errors
- [x] `npm run typecheck` — no type errors
- [x] `npm run format:check` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)