### PR TITLE
feat: expose AlertManager API and wire up plugin lifecycle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,14 @@
  * Implements IEC 62682 alert state machine and IMO alert priority levels.
  */
 
+import { join } from 'path'
 import type { Plugin, ServerAPI } from '@signalk/server-api'
-import type { PluginConfig } from './types.js'
+import type { AlertDefinition, AlertManagerAPI, PluginConfig } from './types.js'
+import { AlertManager, type AlertManagerConfig } from './core/AlertManager.js'
+import { AlertStore } from './store/AlertStore.js'
+import { HistoryStore } from './store/HistoryStore.js'
+import { NotificationTransformer } from './integration/NotificationTransformer.js'
+import { DeltaPublisher } from './integration/DeltaPublisher.js'
 
 // Export all types for use by other plugins and clients
 export type {
@@ -13,6 +19,8 @@ export type {
   AlertState,
   Alert,
   AlertDefinition,
+  AlertManagerAPI,
+  AlertTransitionResult,
   IndicationState,
   RaiseAlertRequest,
   AlertFilter,
@@ -117,22 +125,45 @@ const configSchema = {
   }
 }
 
-/**
- * Signal K plugin factory function.
- * Called by the server to instantiate the plugin.
- */
+/** Resolve PluginConfig to AlertManagerConfig with defaults. */
+function resolveConfig(pluginConfig: PluginConfig): AlertManagerConfig {
+  return {
+    escalation: {
+      enabled: pluginConfig.escalation?.warningToAlarm?.enabled ?? true,
+      timeoutSeconds: pluginConfig.escalation?.warningToAlarm?.timeoutSeconds ?? 300
+    },
+    silencing: {
+      alarmMaxSeconds: pluginConfig.silencing?.alarmMaxSeconds ?? 30,
+      emergencyMaxSeconds: pluginConfig.silencing?.emergencyMaxSeconds ?? 10
+    },
+    sourceTimeout: {
+      markStaleAfterSeconds: pluginConfig.sourceTimeout?.markStaleAfterSeconds ?? 60
+    },
+    retentionDays: pluginConfig.history?.retentionDays ?? 90
+  }
+}
+
 /**
  * Extended plugin interface with internal state access for testing.
  */
 export interface AlertManagerPlugin extends Plugin {
   /** Get the stored restart callback (for testing) */
   getRestartCallback?: () => ((newConfiguration: object) => void) | undefined
+  /** Promise that resolves when async initialization completes */
+  whenReady?: () => Promise<void>
 }
 
 export default function createPlugin(app: ServerAPI): AlertManagerPlugin {
   // Plugin state
   let started = false
   let restartCallback: ((newConfiguration: object) => void) | undefined
+  let manager: AlertManager | undefined
+  let transformer: NotificationTransformer | undefined
+  let publisher: DeltaPublisher | undefined
+  let alertStore: AlertStore | undefined
+  let historyStore: HistoryStore | undefined
+  let readyPromise: Promise<void> | undefined
+  const alertTypes = new Map<string, AlertDefinition>()
 
   const plugin: AlertManagerPlugin = {
     id: 'signalk-alert-manager',
@@ -142,12 +173,99 @@ export default function createPlugin(app: ServerAPI): AlertManagerPlugin {
     schema: configSchema,
 
     start(config: object, restart: (newConfiguration: object) => void): void {
+      if (started) {
+        return
+      }
+
       const pluginConfig = config as PluginConfig
       started = true
       restartCallback = restart
 
       app.debug('Starting alert manager with config:', pluginConfig)
-      app.setPluginStatus('Initialized')
+      app.setPluginStatus('Initializing')
+
+      const managerConfig = resolveConfig(pluginConfig)
+      const dbPath = join(app.getDataDirPath(), 'alerts.db')
+
+      alertStore = new AlertStore(dbPath)
+      historyStore = new HistoryStore(dbPath)
+
+      readyPromise = (async () => {
+        await alertStore.initialize()
+        await historyStore.initialize()
+
+        // stop() may set started=false between awaits; TS can't track this
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (!started) {
+          return
+        }
+
+        const mgr = new AlertManager(managerConfig, undefined, alertStore, historyStore)
+        manager = mgr
+        await mgr.loadFromStore()
+
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (!started) {
+          mgr.stop()
+          return
+        }
+
+        const xformer = new NotificationTransformer({
+          alertManager: mgr,
+          registerDeltaInputHandler: (handler) => {
+            app.registerDeltaInputHandler(handler)
+          },
+          debug: (msg, ...args) => {
+            app.debug(msg, ...args)
+          }
+        })
+        xformer.start()
+        transformer = xformer
+
+        const pub = new DeltaPublisher({
+          alertManager: mgr,
+          handleMessage: (id, delta) => {
+            app.handleMessage(id, delta)
+          },
+          pluginId: plugin.id,
+          debug: (msg, ...args) => {
+            app.debug(msg, ...args)
+          }
+        })
+        pub.start()
+        publisher = pub
+
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (!started) {
+          xformer.stop()
+          pub.stop()
+          mgr.stop()
+          return
+        }
+
+        const api: AlertManagerAPI = {
+          raiseAlert: (params) => mgr.raiseAlert(params),
+          clearCondition: (alertId) => mgr.clearCondition(alertId),
+          acknowledgeAlert: (alertId, userId) => mgr.acknowledgeAlert(alertId, userId),
+          silenceAlert: (alertId, durationMs) => mgr.silenceAlert(alertId, durationMs),
+          silenceAll: () => mgr.silenceAll(),
+          getAlerts: (filter) => mgr.getAlerts(filter),
+          getAlert: (id) => mgr.getAlert(id),
+          getIndicationState: () => mgr.getIndicationState(),
+          registerAlertType: (definition) => {
+            alertTypes.set(definition.alertType, definition)
+          }
+        }
+        app.alertManager = api
+
+        app.setPluginStatus('Running')
+      })()
+
+      readyPromise.catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err)
+        app.error(`Alert manager initialization failed: ${message}`)
+        app.setPluginError(`Initialization failed: ${message}`)
+      })
     },
 
     stop(): void {
@@ -158,10 +276,25 @@ export default function createPlugin(app: ServerAPI): AlertManagerPlugin {
       app.debug('Stopping alert manager')
       started = false
       restartCallback = undefined
+
+      transformer?.stop()
+      publisher?.stop()
+      manager?.stop()
+      delete app.alertManager
+      alertTypes.clear()
+
+      alertStore?.close().catch(() => undefined)
+      historyStore?.close().catch(() => undefined)
+      alertStore = undefined
+      historyStore = undefined
+      manager = undefined
+      transformer = undefined
+      publisher = undefined
+      readyPromise = undefined
     },
 
-    // Test utility to verify restart callback is stored
-    getRestartCallback: () => restartCallback
+    getRestartCallback: () => restartCallback,
+    whenReady: () => readyPromise ?? Promise.resolve()
   }
 
   return plugin

--- a/src/types.ts
+++ b/src/types.ts
@@ -315,6 +315,47 @@ export interface PluginConfig {
 }
 
 // =============================================================================
+// Plugin API Types
+// =============================================================================
+
+/**
+ * Result of a state transition, as returned by the plugin API.
+ */
+export interface AlertTransitionResult {
+  /** The updated alert, or null if the alert was cleared */
+  alert: Alert | null
+  /** Whether the alert was cleared (removed from active alerts) */
+  cleared: boolean
+  /** The state before the transition */
+  previousState: AlertState
+}
+
+/**
+ * Public API exposed on app.alertManager for other Signal K plugins.
+ */
+export interface AlertManagerAPI {
+  raiseAlert(params: RaiseAlertRequest & { sourceId: string }): Promise<Alert>
+  clearCondition(alertId: string): Promise<AlertTransitionResult>
+  acknowledgeAlert(alertId: string, userId?: string): Promise<AlertTransitionResult>
+  silenceAlert(alertId: string, durationMs?: number): Promise<Alert>
+  silenceAll(): Promise<void>
+  getAlerts(filter?: AlertFilter): Alert[]
+  getAlert(id: string): Alert | null
+  getIndicationState(): IndicationState
+  registerAlertType(definition: AlertDefinition): void
+}
+
+// =============================================================================
+// Module Augmentation
+// =============================================================================
+
+declare module '@signalk/server-api' {
+  interface ServerAPI {
+    alertManager?: AlertManagerAPI
+  }
+}
+
+// =============================================================================
 // Interface Types
 // =============================================================================
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -160,6 +160,38 @@ describe('Signal K Plugin', () => {
         void plugin.stop()
       }).not.toThrow()
     })
+
+    it('should handle stop during async initialization', async () => {
+      plugin.start({}, () => {
+        /* restart callback */
+      })
+
+      // Stop immediately before init completes
+      void plugin.stop()
+
+      // Wait for the async chain to settle
+      await new Promise((r) => setTimeout(r, 100))
+
+      // alertManager should not be set since we stopped during init
+      const appWithApi = mockApi as unknown as ServerAPI
+      expect(appWithApi.alertManager).toBeUndefined()
+    })
+
+    it('should guard against double start', async () => {
+      plugin.start({}, () => {
+        /* restart callback */
+      })
+      await plugin.whenReady?.()
+
+      // Second start should be a no-op
+      plugin.start({}, () => {
+        /* restart callback */
+      })
+
+      // Should still be functional
+      const api = (mockApi as unknown as ServerAPI).alertManager
+      expect(api).toBeDefined()
+    })
   })
 
   describe('Configuration Handling', () => {


### PR DESCRIPTION
## Summary

- Adds `AlertManagerAPI` interface and module augmentation extending `ServerAPI` with `app.alertManager`
- Wires up full plugin lifecycle: AlertStore, HistoryStore, AlertManager, NotificationTransformer, and DeltaPublisher
- Exposes API for other plugins to raise/clear/acknowledge/silence alerts and register alert types
- Async initialization with proper error handling and status transitions (Initializing → Running)

## Dependencies

**Must merge after #39 and #40.** This branch includes those changes via merge; will rebase onto main once they land.

## Test plan

- [ ] All 341 tests pass (33 plugin tests including 9 new API/integration tests)
- [ ] Lint, typecheck, and format checks clean
- [ ] Plugin transitions from Initializing to Running on start
- [ ] `app.alertManager` exposed after init with all API methods
- [ ] Notification deltas create alerts through NotificationTransformer
- [ ] Alert changes publish deltas through DeltaPublisher
- [ ] Initialization failure sets error status
- [ ] stop() cleans up all resources and removes API

closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)