### PR TITLE
Add simulation mode for alert UI testing

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -39,7 +39,10 @@ const MAX_MESSAGE_LENGTH = 1000
 export interface RouteDependencies {
   getAlertManager(): AlertManager | undefined
   getHistoryStore(): IHistoryStore | undefined
-  getUiConfig(): { minAudiblePriority: 'off' | 'emergency' | 'alarm' | 'warning' }
+  getUiConfig(): {
+    minAudiblePriority: 'off' | 'emergency' | 'alarm' | 'warning'
+    enableSimulation: boolean
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,18 @@ const configSchema = {
           default: 90
         }
       }
+    },
+    dev: {
+      type: 'object',
+      title: 'Developer Settings',
+      properties: {
+        enableSimulation: {
+          type: 'boolean',
+          title: 'Enable Simulation',
+          description: 'Show the alert simulation button in the UI toolbar',
+          default: false
+        }
+      }
     }
   }
 }
@@ -127,6 +139,7 @@ const configSchema = {
 /** UI config exposed to the browser via GET /config/ui. */
 interface UiConfig {
   minAudiblePriority: 'off' | 'emergency' | 'alarm' | 'warning'
+  enableSimulation: boolean
 }
 
 /** Resolve PluginConfig to AlertManagerConfig with defaults. */
@@ -150,7 +163,8 @@ function resolveConfig(pluginConfig: PluginConfig): AlertManagerConfig {
 /** Resolve UI-only config from plugin config. */
 function resolveUiConfig(pluginConfig: PluginConfig): UiConfig {
   return {
-    minAudiblePriority: pluginConfig.audio?.minAudiblePriority ?? 'warning'
+    minAudiblePriority: pluginConfig.audio?.minAudiblePriority ?? 'warning',
+    enableSimulation: pluginConfig.dev?.enableSimulation ?? false
   }
 }
 
@@ -176,7 +190,7 @@ export default function createPlugin(app: ServerAPI): AlertManagerPlugin {
   let alertStore: AlertStore | undefined
   let historyStore: HistoryStore | undefined
   let readyPromise: Promise<void> | undefined
-  let uiConfig: UiConfig = { minAudiblePriority: 'warning' }
+  let uiConfig: UiConfig = { minAudiblePriority: 'warning', enableSimulation: false }
   const alertTypes = new Map<string, AlertDefinition>()
 
   const plugin: AlertManagerPlugin = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -310,6 +310,12 @@ export interface PluginConfig {
     /** Minimum priority that triggers audible alerts: 'off', 'emergency', 'alarm', or 'warning' (default: 'warning') */
     minAudiblePriority?: 'off' | 'emergency' | 'alarm' | 'warning'
   }
+
+  /** Developer/testing settings */
+  dev?: {
+    /** Show the simulation button in the alert list toolbar (default: false) */
+    enableSimulation?: boolean
+  }
 }
 
 // =============================================================================

--- a/src/ui/components/alert-list.ts
+++ b/src/ui/components/alert-list.ts
@@ -5,14 +5,17 @@
  * elements for each alert.
  */
 
-import { LitElement, html, css } from 'lit'
+import { LitElement, html, css, nothing } from 'lit'
 import type { Alert } from '../../types.js'
 import { AlertService } from '../services/alert-service.js'
 import { AudioService } from '../services/audio-service.js'
+import { SimulationService } from '../services/simulation-service.js'
 
 export class AlertList extends LitElement {
   static properties = {
-    alerts: { state: true }
+    alerts: { state: true },
+    simulationRunning: { state: true },
+    simulationEnabled: { state: true }
   }
 
   static styles = css`
@@ -59,6 +62,39 @@ export class AlertList extends LitElement {
       cursor: not-allowed;
     }
 
+    .toolbar-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    button[data-action='simulate'] {
+      min-height: 44px;
+      min-width: 44px;
+      padding: 0.375rem 0.75rem;
+      border: 1px solid #e65100;
+      border-radius: 4px;
+      background: #fff;
+      color: #e65100;
+      font-size: 0.8rem;
+      font-weight: 600;
+      cursor: pointer;
+      touch-action: manipulation;
+      white-space: nowrap;
+    }
+
+    button[data-action='simulate']:hover {
+      background: #fff3e0;
+    }
+
+    button[data-action='simulate'].sim-active {
+      background: #e65100;
+      color: #fff;
+    }
+
+    button[data-action='simulate'].sim-active:hover {
+      background: #bf360c;
+    }
+
     .empty {
       text-align: center;
       padding: 2rem;
@@ -73,13 +109,18 @@ export class AlertList extends LitElement {
   `
 
   declare alerts: Alert[]
+  declare simulationRunning: boolean
+  declare simulationEnabled: boolean
 
   private service = new AlertService()
   private audioService = new AudioService()
+  private simulation = new SimulationService(() => this.service.getAlerts())
 
   constructor() {
     super()
     this.alerts = []
+    this.simulationRunning = false
+    this.simulationEnabled = false
   }
 
   connectedCallback(): void {
@@ -96,16 +137,26 @@ export class AlertList extends LitElement {
   private fetchUiConfig(): void {
     const VALID_PRIORITIES = new Set(['off', 'emergency', 'alarm', 'warning'])
     fetch('/plugins/signalk-alert-manager/config/ui')
-      .then((res) => (res.ok ? (res.json() as Promise<{ minAudiblePriority: string }>) : null))
+      .then((res) =>
+        res.ok
+          ? (res.json() as Promise<{
+              minAudiblePriority?: string
+              enableSimulation?: boolean
+            }>)
+          : null
+      )
       .then((config) => {
         if (config?.minAudiblePriority && VALID_PRIORITIES.has(config.minAudiblePriority)) {
           this.audioService.setMinAudiblePriority(
             config.minAudiblePriority as 'off' | 'emergency' | 'alarm' | 'warning'
           )
         }
+        if (config?.enableSimulation === true) {
+          this.simulationEnabled = true
+        }
       })
       .catch(() => {
-        // Config fetch failed; audio uses default (warning)
+        // Config fetch failed; defaults apply
       })
   }
 
@@ -114,6 +165,7 @@ export class AlertList extends LitElement {
     this.service.removeEventListener('change', this.onServiceChange)
     this.removeEventListener('alert-acknowledge', this.onAlertAcknowledge as EventListener)
     this.removeEventListener('alert-silence', this.onAlertSilence as EventListener)
+    this.simulation.stop()
     this.service.disconnect()
     this.audioService.dispose()
   }
@@ -145,6 +197,15 @@ export class AlertList extends LitElement {
       )
   }
 
+  private onToggleSimulation(): void {
+    if (this.simulation.running) {
+      this.simulation.stop()
+    } else {
+      this.simulation.start()
+    }
+    this.simulationRunning = this.simulation.running
+  }
+
   private onSilenceAll(): void {
     this.service.silenceAll().catch(() => {
       // Error handling — state will remain unchanged via WebSocket
@@ -157,13 +218,24 @@ export class AlertList extends LitElement {
         <span class="alert-count"
           >${String(this.alerts.length)} alert${this.alerts.length !== 1 ? 's' : ''}</span
         >
-        <button
-          data-action="silence-all"
-          ?disabled=${!this.hasUnsilencedUnacknowledged()}
-          @click=${this.onSilenceAll}
-        >
-          Silence All
-        </button>
+        <div class="toolbar-actions">
+          ${this.simulationEnabled
+            ? html`<button
+                data-action="simulate"
+                class=${this.simulationRunning ? 'sim-active' : ''}
+                @click=${this.onToggleSimulation}
+              >
+                ${this.simulationRunning ? 'Stop Sim' : 'Simulate'}
+              </button>`
+            : nothing}
+          <button
+            data-action="silence-all"
+            ?disabled=${!this.hasUnsilencedUnacknowledged()}
+            @click=${this.onSilenceAll}
+          >
+            Silence All
+          </button>
+        </div>
       </div>
 
       ${this.alerts.length === 0

--- a/src/ui/services/simulation-service.ts
+++ b/src/ui/services/simulation-service.ts
@@ -1,0 +1,121 @@
+/**
+ * SimulationService — generates random alerts for UI development and demos.
+ *
+ * Entirely client-side: calls the existing REST API to raise alerts and
+ * clear conditions. Start/stop via the toggle in the AlertList toolbar.
+ */
+
+import type { Alert, AlertPriority } from '../../types.js'
+
+const API_BASE = '/plugins/signalk-alert-manager'
+const TICK_MS = 2000
+
+const RAISE_PROBABILITY = 0.114
+const CLEAR_ACKED_PROBABILITY = 0.133
+const CLEAR_UNACKED_PROBABILITY = 0.017
+
+const PRIORITY_WEIGHTS: Array<{ priority: AlertPriority; weight: number }> = [
+  { priority: 'emergency', weight: 0.05 },
+  { priority: 'alarm', weight: 0.15 },
+  { priority: 'warning', weight: 0.4 },
+  { priority: 'caution', weight: 0.4 }
+]
+
+const SCENARIOS: Array<{ message: string; category: string }> = [
+  { message: 'Engine coolant temperature high', category: 'engine' },
+  { message: 'Low oil pressure', category: 'engine' },
+  { message: 'Battery voltage below threshold', category: 'electrical' },
+  { message: 'Bilge water level high', category: 'safety' },
+  { message: 'GPS signal lost', category: 'navigation' },
+  { message: 'AIS target CPA alarm', category: 'navigation' },
+  { message: 'Anchor drag detected', category: 'navigation' },
+  { message: 'Depth below minimum', category: 'navigation' },
+  { message: 'Fuel level low', category: 'engine' },
+  { message: 'Rudder angle sensor fault', category: 'steering' }
+]
+
+export class SimulationService {
+  private intervalId: ReturnType<typeof setInterval> | null = null
+  private counter = 0
+  private getAlerts: () => Alert[]
+
+  constructor(getAlerts: () => Alert[]) {
+    this.getAlerts = getAlerts
+  }
+
+  get running(): boolean {
+    return this.intervalId !== null
+  }
+
+  start(): void {
+    if (this.intervalId !== null) return
+    this.intervalId = setInterval(() => this.tick(), TICK_MS)
+  }
+
+  stop(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+    }
+  }
+
+  /** Single simulation tick — fire-and-forget, no awaiting. */
+  private tick(): void {
+    const alerts = this.getAlerts()
+
+    // Always raise if there are no alerts, otherwise use probability
+    if (alerts.length === 0 || Math.random() < RAISE_PROBABILITY) {
+      this.raiseRandomAlert()
+    }
+
+    for (const alert of alerts) {
+      const threshold =
+        alert.state === 'acknowledged' ? CLEAR_ACKED_PROBABILITY : CLEAR_UNACKED_PROBABILITY
+      if (Math.random() < threshold) {
+        this.clearAlert(alert.id)
+      }
+    }
+  }
+
+  private raiseRandomAlert(): void {
+    const scenario = SCENARIOS[Math.floor(Math.random() * SCENARIOS.length)]
+    const { priority } = pickWeighted(PRIORITY_WEIGHTS)
+    const latching = Math.random() < 0.3
+    const sourceId = `simulation-${String(++this.counter)}`
+
+    fetch(`${API_BASE}/alerts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceId,
+        priority,
+        message: `SIM: ${scenario.message}`,
+        category: scenario.category,
+        latching
+      })
+    }).catch(() => {
+      // Fire-and-forget
+    })
+  }
+
+  private clearAlert(id: string): void {
+    fetch(`${API_BASE}/alerts/${id}/condition`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ active: false })
+    }).catch(() => {
+      // Fire-and-forget
+    })
+  }
+}
+
+/** Pick a value from a weighted distribution. Exported for testing. */
+export function pickWeighted<T>(items: Array<{ weight: number } & T>): T {
+  const r = Math.random()
+  let cumulative = 0
+  for (const item of items) {
+    cumulative += item.weight
+    if (r < cumulative) return item
+  }
+  return items[items.length - 1]
+}

--- a/test/ui/components/alert-list.test.ts
+++ b/test/ui/components/alert-list.test.ts
@@ -487,6 +487,66 @@ describe('AlertList', () => {
     })
   })
 
+  describe('simulation button', () => {
+    it('does not render simulate button by default', async () => {
+      const el = document.createElement('alert-list') as HTMLElement & {
+        updateComplete: Promise<boolean>
+      }
+      document.body.appendChild(el)
+      await updateComplete(el)
+      await new Promise((r) => setTimeout(r, 0))
+      await updateComplete(el)
+
+      const btn = shadowQuery(el, '[data-action="simulate"]')
+      expect(btn).toBeNull()
+    })
+
+    it('renders simulate button when simulationEnabled is true', async () => {
+      const el = document.createElement('alert-list') as HTMLElement & {
+        simulationEnabled: boolean
+        updateComplete: Promise<boolean>
+      }
+      el.simulationEnabled = true
+      document.body.appendChild(el)
+      await updateComplete(el)
+      await new Promise((r) => setTimeout(r, 0))
+      await updateComplete(el)
+
+      const btn = shadowQuery(el, '[data-action="simulate"]')
+      expect(btn).not.toBeNull()
+      expect(btn?.textContent).toContain('Simulate')
+    })
+
+    it('toggles button text and class on click', async () => {
+      const el = document.createElement('alert-list') as HTMLElement & {
+        simulationEnabled: boolean
+        updateComplete: Promise<boolean>
+      }
+      el.simulationEnabled = true
+      document.body.appendChild(el)
+      await updateComplete(el)
+      await new Promise((r) => setTimeout(r, 0))
+      await updateComplete(el)
+
+      const btn = shadowQuery(el, '[data-action="simulate"]') as HTMLButtonElement
+      expect(btn.classList.contains('sim-active')).toBe(false)
+
+      btn.click()
+      await updateComplete(el)
+
+      const btnAfter = shadowQuery(el, '[data-action="simulate"]') as HTMLButtonElement
+      expect(btnAfter.textContent).toContain('Stop Sim')
+      expect(btnAfter.classList.contains('sim-active')).toBe(true)
+
+      btnAfter.click()
+      await updateComplete(el)
+
+      const btnFinal = shadowQuery(el, '[data-action="simulate"]') as HTMLButtonElement
+      expect(btnFinal.textContent).toContain('Simulate')
+      expect(btnFinal.classList.contains('sim-active')).toBe(false)
+    })
+  })
+
   describe('event handling', () => {
     it('calls service acknowledgeAlert on alert-acknowledge event', async () => {
       const alerts = [makeAlert({ id: 'evt-1', state: 'unacknowledged', priority: 'warning' })]

--- a/test/ui/services/simulation-service.test.ts
+++ b/test/ui/services/simulation-service.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SimulationService, pickWeighted } from '../../../src/ui/services/simulation-service.js'
+import type { Alert } from '../../../src/types.js'
+
+function makeAlert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    id: crypto.randomUUID(),
+    sourceId: 'test',
+    priority: 'warning',
+    state: 'unacknowledged',
+    condition: true,
+    latching: false,
+    silenced: false,
+    message: 'Test alert',
+    raisedAt: new Date().toISOString(),
+    sourceOnline: true,
+    lastSourceUpdate: new Date().toISOString(),
+    stale: false,
+    ...overrides
+  }
+}
+
+describe('SimulationService', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    vi.stubGlobal('fetch', fetchMock)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('starts and stops correctly', () => {
+    const sim = new SimulationService(() => [])
+    expect(sim.running).toBe(false)
+
+    sim.start()
+    expect(sim.running).toBe(true)
+
+    sim.stop()
+    expect(sim.running).toBe(false)
+  })
+
+  it('does not create duplicate intervals on repeated start', () => {
+    const sim = new SimulationService(() => [])
+    sim.start()
+    sim.start()
+    expect(sim.running).toBe(true)
+
+    // Verify only one interval fires per tick
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    vi.advanceTimersByTime(2000)
+    // With no alerts, it always raises — so exactly one fetch call
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    sim.stop()
+  })
+
+  it('always raises an alert when no alerts exist', () => {
+    const sim = new SimulationService(() => [])
+    sim.start()
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.99)
+    vi.advanceTimersByTime(2000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe('/plugins/signalk-alert-manager/alerts')
+    expect(opts.method).toBe('POST')
+
+    const body = JSON.parse(opts.body)
+    expect(typeof body.priority).toBe('string')
+    expect(['emergency', 'alarm', 'warning', 'caution']).toContain(body.priority)
+    expect(body.message).toMatch(/^SIM: /)
+    expect(body.sourceId).toMatch(/^simulation-\d+$/)
+
+    sim.stop()
+  })
+
+  it('raises with probability when alerts exist', () => {
+    const alerts = [makeAlert()]
+    const sim = new SimulationService(() => alerts)
+    sim.start()
+
+    // 0.05 < 0.114 → raise triggered. Then raiseRandomAlert calls random
+    // for scenario index, pickWeighted, and latching check.
+    // Finally the clear loop calls random: 0.005 < 0.017 → clear unacked.
+    let callIdx = 0
+    const values = [
+      0.05, // raise check → yes
+      0.5, // scenario index
+      0.5, // pickWeighted
+      0.5, // latching check
+      0.005 // clear check for the one unacked alert → yes (< 0.017)
+    ]
+    vi.spyOn(Math, 'random').mockImplementation(() => values[callIdx++] ?? 0.5)
+    vi.advanceTimersByTime(2000)
+
+    // One raise + one clear = 2 fetch calls
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    sim.stop()
+  })
+
+  it('does not raise when random exceeds threshold and alerts exist', () => {
+    const alerts = [makeAlert({ state: 'acknowledged' })]
+    const sim = new SimulationService(() => alerts)
+    sim.start()
+
+    // 0.5 > 0.114 → no raise, 0.5 > 0.133 → no clear acked
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    vi.advanceTimersByTime(2000)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    sim.stop()
+  })
+
+  it('clears acknowledged alerts at higher probability than unacknowledged', () => {
+    const acked = makeAlert({ id: 'acked-1', state: 'acknowledged' })
+    const unacked = makeAlert({ id: 'unacked-1', state: 'unacknowledged' })
+    const sim = new SimulationService(() => [acked, unacked])
+    sim.start()
+
+    // 0.05 is between the two clear thresholds (0.017 < 0.05 < 0.133),
+    // so only the acked alert gets cleared.
+    let callCount = 0
+    vi.spyOn(Math, 'random').mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return 0.5 // raise check → no (> 0.114)
+      if (callCount === 2) return 0.05 // acked clear → yes (< 0.133)
+      if (callCount === 3) return 0.05 // unacked clear → no (> 0.017)
+      return 0.5
+    })
+
+    vi.advanceTimersByTime(2000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toContain('acked-1')
+
+    sim.stop()
+  })
+
+  it('uses unique sourceId for each raised alert', () => {
+    const sim = new SimulationService(() => [])
+    sim.start()
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.99)
+    vi.advanceTimersByTime(2000)
+    vi.advanceTimersByTime(2000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    const body1 = JSON.parse(fetchMock.mock.calls[0][1].body)
+    const body2 = JSON.parse(fetchMock.mock.calls[1][1].body)
+    expect(body1.sourceId).not.toBe(body2.sourceId)
+    expect(body1.sourceId).toMatch(/^simulation-\d+$/)
+
+    sim.stop()
+  })
+})
+
+describe('pickWeighted', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('picks first item when random is below first weight', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.01)
+    const items = [
+      { value: 'a', weight: 0.05 },
+      { value: 'b', weight: 0.95 }
+    ]
+    const result = pickWeighted(items)
+    expect(result.value).toBe('a')
+  })
+
+  it('picks second item when random exceeds first weight', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.06)
+    const items = [
+      { value: 'a', weight: 0.05 },
+      { value: 'b', weight: 0.95 }
+    ]
+    const result = pickWeighted(items)
+    expect(result.value).toBe('b')
+  })
+
+  it('returns last item as fallback for edge case', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.9999999)
+    const items = [
+      { value: 'a', weight: 0.5 },
+      { value: 'b', weight: 0.5 }
+    ]
+    const result = pickWeighted(items)
+    expect(result.value).toBe('b')
+  })
+
+  it('handles boundary between weights correctly', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.049)
+    const items = [
+      { value: 'emergency', weight: 0.05 },
+      { value: 'alarm', weight: 0.15 },
+      { value: 'warning', weight: 0.4 },
+      { value: 'caution', weight: 0.4 }
+    ]
+    const result = pickWeighted(items)
+    expect(result.value).toBe('emergency')
+  })
+})


### PR DESCRIPTION
## Summary

- Client-side `SimulationService` that generates random alerts via the existing REST API, with realistic raise/clear probabilities
- Orange toggle button in the AlertList toolbar to start/stop simulation
- Useful for UI development and demos without needing real alert sources

## Design

- Ticks every 2s; always raises when no alerts exist, otherwise 11.4% raise chance per tick
- Clears acknowledged alerts at 13.3%/tick, unacknowledged at 1.7%/tick (acknowledged clear ~8x faster)
- 10 marine alert scenarios, weighted priority distribution (5% emergency, 15% alarm, 40% warning, 40% caution), 30% latching
- Unique `sourceId` per alert to avoid backend deduplication
- Fire-and-forget API calls; no cleanup on stop so alerts persist for interaction

## Test plan

- [x] `npx vitest run --config vitest.config.ui.ts` — 166 tests pass
- [x] `npm run build:ui` — builds without errors
- [ ] Manual: click Simulate, observe alerts appearing and clearing, verify audio plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)