### PR TITLE
Add complete README, CHANGELOG, and update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,33 +12,66 @@ Signal K server plugin for centralized alert management following maritime (IMO 
 | `docs/ARCHITECTURE.md` | System design and component structure | Major changes, understanding data flow |
 | `src/types.ts` | TypeScript type definitions | Working with alert data structures |
 | `src/test/MockServerAPI.ts` | Mock Signal K ServerAPI for testing | Writing unit tests |
+| `src/api/openApi.json` | OpenAPI specification for REST endpoints | Modifying or documenting API |
 | `package.json` | Dependencies, scripts, plugin metadata | Build issues, adding dependencies |
 
-## Project Structure (Planned)
+## Project Structure
 
 ```
 signalk-alert-manager/
-├── docs/                           # Specifications
+├── docs/
 │   ├── SPEC.md                     # Full requirements specification
-│   └── ARCHITECTURE.md             # System design
+│   ├── ARCHITECTURE.md             # System design
+│   └── IMPLEMENTATION_CHECKLIST.md # Implementation tracking
 ├── src/
-│   ├── index.ts                    # Plugin entry point
+│   ├── index.ts                    # Plugin entry point, config schema
 │   ├── types.ts                    # TypeScript type definitions
-│   ├── core/                       # Alert lifecycle management
+│   ├── core/
 │   │   ├── AlertManager.ts         # Main orchestrator
-│   │   └── AlertStateMachine.ts    # State transitions per IEC 62682
-│   ├── store/                      # Persistence layer
-│   │   ├── AlertStore.ts           # SQLite storage via node:sqlite
-│   │   └── HistoryStore.ts         # Alert history logging
-│   ├── integration/                # Signal K integration
+│   │   ├── AlertStateMachine.ts    # State transitions per IEC 62682
+│   │   └── EscalationTimer.ts      # Warning-to-alarm escalation
+│   ├── store/
+│   │   ├── AlertStore.ts           # SQLite alert persistence via node:sqlite
+│   │   └── HistoryStore.ts         # SQLite alert history logging
+│   ├── integration/
 │   │   ├── NotificationTransformer.ts  # SK notification to alert bridge
 │   │   └── DeltaPublisher.ts       # Alert state to SK delta output
-│   ├── api/                        # REST API handlers
-│   │   └── routes.ts               # Express routes
-│   ├── ui/                         # Web UI (TBD)
-│   └── test/                       # Test utilities
+│   ├── api/
+│   │   ├── routes.ts               # Express REST API handlers
+│   │   └── openApi.json            # OpenAPI specification
+│   ├── ui/
+│   │   ├── index.html              # Vite entry point
+│   │   ├── main.ts                 # UI bootstrap
+│   │   ├── components/
+│   │   │   ├── alert-app.ts        # Root app component (Lit)
+│   │   │   ├── alert-list.ts       # Alert list with toolbar
+│   │   │   ├── alert-card.ts       # Individual alert display
+│   │   │   ├── alert-detail.ts     # Expanded alert view
+│   │   │   └── alert-banner.ts     # Embeddable compact banner
+│   │   ├── services/
+│   │   │   ├── alert-service.ts    # REST + WebSocket client
+│   │   │   ├── audio-service.ts    # Browser audio playback
+│   │   │   └── simulation-service.ts # Dev simulation controls
+│   │   ├── styles/
+│   │   │   ├── priority.ts         # Priority color/styling constants
+│   │   │   └── icons.ts            # SVG icon definitions
+│   │   └── utils/
+│   │       └── format.ts           # Formatting helpers
+│   └── test/
 │       └── MockServerAPI.ts        # Mock ServerAPI for unit tests
-└── test/                           # Test files
+├── test/
+│   ├── core/                       # AlertManager, StateMachine, Escalation tests
+│   ├── store/                      # AlertStore, HistoryStore tests
+│   ├── integration/                # NotificationTransformer, DeltaPublisher tests
+│   ├── api/                        # REST API route tests, OpenAPI validation
+│   ├── ui/                         # Lit component and service tests
+│   ├── e2e/                        # End-to-end tests with real SK server
+│   └── helpers/                    # Test utilities
+├── public/                         # Built UI output (Vite build target)
+├── package.json
+├── tsconfig.json
+├── vite.config.ts
+└── vitest.config.*.ts              # Vitest configs (default, UI, e2e)
 ```
 
 ## Alert Model
@@ -70,13 +103,30 @@ States B and D flash visual indicators and sound audible alerts per priority.
 
 ```bash
 npm run build          # Compile TypeScript
-npm run test           # Run Vitest tests
+npm run build:ui       # Build UI with Vite (output to public/)
+npm run dev:ui         # Vite dev server for UI
+npm run test           # Run all Vitest tests
+npm run test:ui        # Run UI component tests (happy-dom)
+npm run test:e2e       # Run end-to-end tests
 npm run lint           # ESLint check
 npm run format         # Prettier format
 npm run ci             # Full CI check (typecheck + lint + format + test)
 ```
 
 ## Technical Notes
+
+### Technology Stack
+
+| Layer | Technology |
+|-------|------------|
+| Language | TypeScript (ESM) |
+| Runtime | Node.js 22+ (required for `node:sqlite`) |
+| HTTP | Express (provided by SK server) |
+| Persistence | SQLite via `node:sqlite` (built-in, experimental) |
+| Web UI | [Lit](https://lit.dev/) web components, plain CSS |
+| UI Build | Vite |
+| Testing | Vitest + happy-dom (for UI tests) |
+| Linting | ESLint + Prettier |
 
 ### Node.js Requirement
 
@@ -88,13 +138,12 @@ Requires **Node.js 22+** with `--experimental-sqlite` flag for the built-in `nod
 |--------|---------|
 | `app.registerDeltaInputHandler()` | Intercept incoming notifications |
 | `app.handleMessage()` | Publish alert deltas |
-| `app.streambundle.getSelfBus()` | Subscribe to path changes |
 | `plugin.registerWithRouter()` | REST API endpoints |
 | `app.getDataDirPath()` | SQLite database location |
 
 ### API Base Path
 
-REST endpoints live at `/plugins/signalk-alert-manager/alerts/*`. See SPEC.md Section 6 for full API documentation.
+REST endpoints live at `/plugins/signalk-alert-manager/`. See `src/api/openApi.json` for the full OpenAPI specification and `docs/SPEC.md` Section 6 for endpoint documentation.
 
 ### SK Notification to Alert Mapping
 
@@ -105,6 +154,21 @@ REST endpoints live at `/plugins/signalk-alert-manager/alerts/*`. See SPEC.md Se
 | `warn`, `warning` | Warning (W) |
 | `alert` | Caution (C) |
 | `normal`, `nominal` | Clear condition |
+
+### Configuration Schema
+
+Plugin config is defined in `src/index.ts` (`configSchema`). Key settings:
+
+| Group | Setting | Default |
+|-------|---------|---------|
+| Audio | `minAudiblePriority` | `warning` |
+| Silencing | `defaultMaxSilenceSeconds` | 120 |
+| Silencing | `emergencyMaxSilenceSeconds` | 30 |
+| Escalation | `warningToAlarm.enabled` | true |
+| Escalation | `warningToAlarm.timeoutSeconds` | 300 |
+| Source Timeout | `markStaleAfterSeconds` | 60 |
+| History | `retentionDays` | 90 |
+| Dev | `enableSimulation` | false |
 
 ## Testing Patterns
 
@@ -132,16 +196,18 @@ const deltas = mockApi.getCapturedDeltas()
 ### Test Categories
 
 - **State machine tests**: Verify IEC 62682 state transitions
-- **API tests**: REST endpoint behavior
-- **Integration tests**: SK notification transformation
-- **Store tests**: Persistence and history queries
+- **API tests**: REST endpoint behavior and OpenAPI spec validation
+- **Integration tests**: SK notification transformation, delta publishing
+- **Store tests**: SQLite persistence and history queries
+- **UI tests**: Lit component rendering and interaction (happy-dom)
+- **E2E tests**: Full lifecycle with real Signal K server
 
 ## Standards References
 
 - **IMO MSC.302(87)**: Bridge Alert Management Performance Standards
 - **IMO A.1021(26)**: Code on Alerts and Indicators
 - **IEC 62682:2023**: Management of alarm systems for the process industries
-- **OpenBridge**: Maritime UI design guidelines (for future UI work)
+- **OpenBridge**: Maritime UI design guidelines
 
 ## Related Repos
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - 2026-02-25
+
+Initial release.
+
+### Added
+
+- Alert lifecycle management (raise, acknowledge, silence, clear) based on IEC 62682 state model
+- Four IMO priority levels: emergency, alarm, warning, caution
+- Automatic escalation of unacknowledged warnings to alarms
+- Time-limited silencing with configurable durations per priority
+- Latching support for one-shot event alerts
+- Source liveness tracking with stale alert detection
+- SQLite persistence for alerts and full audit history (via Node.js 22 `node:sqlite`)
+- REST API for all alert operations
+- Plugin API (`app.alertManager`) for inter-plugin integration
+- Signal K notification interception and automatic transformation to managed alerts
+- Delta publishing for real-time WebSocket updates
+- Web UI with alert list, alert detail view, alert banner, and audio indicators (Lit web components)
+- OpenAPI specification for REST endpoints
+- Alert history with query/filter API and configurable retention

--- a/README.md
+++ b/README.md
@@ -1,32 +1,373 @@
 # signalk-alert-manager
 
-Signal K server plugin for centralized alert management following maritime (IMO) and process industry (IEC) standards.
+Signal K server plugin for centralized alert management following maritime and process industry standards.
 
-## Overview
+## Why This Plugin?
 
-This plugin transforms Signal K's ad-hoc notification model into a structured alert system with:
-- Proper lifecycle management (raise, acknowledge, silence, clear)
-- IMO-defined alert priorities (Emergency, Alarm, Warning, Caution)
-- IEC 62682 state model
-- Real-time synchronization across clients
-- Persistence across restarts
+Signal K's built-in notification system (`notifications.*` paths) provides a basic mechanism for communicating abnormal conditions, but it was designed as a simple key-value signaling layer rather than a full alert management system. As vessels become more instrumented, the gaps become limiting:
 
-## Documentation
+**Signal K notifications are stateless.** A notification is a value at a path — `{ state, method, message }`. There is no lifecycle: no concept of "this alert was raised at time T, acknowledged by person P, and cleared at time T2." When a source updates a notification, the previous state is gone.
 
-- [Specification](docs/SPEC.md) - Full technical specification
+**No acknowledgment.** Maritime safety standards (IMO MSC.302(87)) require that operators explicitly acknowledge alerts to confirm awareness. Signal K has no built-in acknowledgment mechanism — the server provides no endpoints or state tracking for it. Acknowledgment requires third-party plugins that modify the `method` or `state` fields as a workaround.
 
-## Status
+**No persistence.** Notifications exist only in the server's in-memory delta cache. On restart, all notifications are lost. A zone-based alarm will re-trigger when new data arrives, but manually-raised notifications and any acknowledgment state disappear entirely.
 
-**In Development** - This project is currently in the planning and design phase.
+**No silencing or escalation.** There is no way to temporarily suppress an audible alert without clearing it, and no mechanism for escalating an ignored warning to a higher priority level.
 
-## References
+**No history or audit trail.** There is no built-in way to query what alerts occurred in the past, when they were acknowledged, or by whom — information that may be required for compliance and is always useful for troubleshooting.
 
-- [IMO MSC.302(87)](https://www.imo.org/en/OurWork/Safety/Pages/BridgeAlertManagement.aspx) - Bridge Alert Management Performance Standards
-- [IMO A.1021(26)](https://www.imo.org/en/KnowledgeCentre/IndexofIMOResolutions/Pages/A-2009-11.aspx) - Code on Alerts and Indicators
-- [OpenBridge Design System](https://www.openbridge.no/)
-- [Signal K Specification](https://signalk.org/specification/)
-- [GitHub Issue #1857](https://github.com/SignalK/signalk-server/issues/1857) - Data model and lifecycle for alerts
+signalk-alert-manager addresses each of these gaps by implementing a proper alert lifecycle based on IEC 62682 (process industry alarm management) and IMO MSC.302(87) (bridge alert management), while integrating seamlessly with existing Signal K notifications.
+
+### Signal K Notifications vs Alert Manager
+
+| Capability | Signal K Notifications | Alert Manager |
+|---|---|---|
+| Data model | Key-value at `notifications.*` paths | Alert objects with unique IDs, full metadata |
+| States | `normal`, `nominal`, `alert`, `warn`, `alarm`, `emergency` | IEC 62682: unacknowledged, acknowledged, return-to-normal |
+| Lifecycle | None — value replaced on update | Raise → acknowledge → clear with full tracking |
+| Acknowledgment | Not supported | Per-alert, records who and when |
+| Silencing | Not supported | Time-limited, configurable per priority |
+| Escalation | Not supported | Automatic priority promotion on timeout |
+| Persistence | In-memory only (lost on restart) | SQLite — survives restarts |
+| History | None | Full audit trail with query API |
+| Source tracking | `$source` field | Source liveness monitoring, stale detection |
+| Priority model | Implicit in state string | Four explicit levels (IMO model) with defined behaviors |
+| Creation | Zone triggers or manual deltas | Notifications auto-imported, plus REST API and plugin API |
+
+The two systems are complementary: existing `notifications.*` paths continue to work as before, and the alert manager automatically intercepts them to create managed alerts with full lifecycle support.
+
+## Alert Model
+
+### Priority Levels
+
+Four priority levels follow the IMO model, from most to least urgent:
+
+| Priority | When to Use | Audible | Requires Acknowledgment |
+|---|---|---|---|
+| **Emergency** | Immediate danger to life or vessel | Rapid 5-pulse burst, repeating | Yes |
+| **Alarm** | Conditions requiring immediate attention | 3-pulse triplet, repeating | Yes |
+| **Warning** | Conditions requiring precautionary attention | 2-pulse chime, repeating | Yes |
+| **Caution** | Noteworthy conditions, not immediately hazardous | None | No |
+
+All audible patterns repeat until the alert is acknowledged or silenced. Each priority has a distinct frequency (880/660/440 Hz) and pulse pattern inspired by IEC 60601-1-8.
+
+### Alert Lifecycle
+
+Alerts follow the IEC 62682 state model:
+
+```
+                 condition                    condition clears
+  NORMAL ──────triggers──────► UNACKNOWLEDGED ──────────────────► RTN-UNACKNOWLEDGED
+                                     │                                    │
+                              operator acks                        operator acks
+                                     │                                    │
+                                     ▼          condition clears          ▼
+                               ACKNOWLEDGED ──────────────────────► NORMAL
+```
+
+- **Unacknowledged**: Alert is active, operator has not yet responded. Visual indicators flash, audible alerts sound per priority.
+- **Acknowledged**: Operator confirmed awareness. Visual indicators show steady, audible alerts stop.
+- **Return-to-normal unacknowledged**: The triggering condition cleared before the operator acknowledged. Audible alert continues until acknowledged or silenced.
+
+Caution-priority alerts skip acknowledgment — they clear automatically when the condition resolves.
+
+### Latching
+
+Some alerts represent one-shot events (e.g., waypoint arrival, anchor drag detected) where the triggering condition is momentary. Latching alerts remain active after the condition clears and must be explicitly acknowledged to dismiss.
+
+### Silencing
+
+Silencing suppresses audible indicators without acknowledging the alert. It is time-limited:
+- Non-emergency alerts: configurable, default 120 seconds
+- Emergencies: shorter limit, default 30 seconds
+- A global "silence all" action affects all unacknowledged alerts (including return-to-normal unacknowledged)
+
+### Escalation
+
+Unacknowledged warnings automatically escalate to alarm priority after a configurable timeout (default: 5 minutes). This ensures ignored warnings eventually demand attention.
+
+### Source Tracking
+
+Each alert tracks its source. If a source stops sending updates, the alert is marked **stale** after a configurable timeout (default: 60 seconds). Stale alerts remain visible and actionable but are visually distinguished in the UI.
+
+### Actors and Ownership
+
+**Who creates alerts?** Alerts enter the system through three paths:
+
+- **Signal K notifications** — The plugin automatically intercepts incoming `notifications.*` deltas and transforms them into managed alerts. This is how zone-based alarms and other plugins' notifications enter the system. The alert's `sourceId` is set to `notifications:<path>` where `<path>` is the full delta path including the `notifications.` prefix (e.g., `notifications:notifications.propulsion.main.coolantTemperature`).
+- **Plugin API** — Other Signal K plugins raise alerts programmatically by calling `app.alertManager.raiseAlert()`, providing their own `sourceId` to identify themselves.
+- **REST API** — Authenticated HTTP clients raise alerts via `POST /alerts`. The caller can provide a `sourceId`; if omitted, it defaults to `rest-api`.
+
+When the same source raises an alert with the same message as an existing active alert, the existing alert is updated (timestamp refreshed, priority escalated if higher) rather than creating a duplicate.
+
+**Who can acknowledge, silence, and clear?** Any authenticated user can perform any operation on any alert, regardless of who raised it. There is no per-alert ownership or role-based restriction. This is intentional: in a bridge context, any watchkeeper must be able to respond to any alert immediately. The operator's identity is recorded for audit purposes (in `acknowledgedBy` and in the history log) but is not used for access control.
+
+**Who manages alert state?** The `AlertManager` is the single source of truth. All state transitions — whether triggered by the REST API, the plugin API, or the notification transformer — pass through the AlertManager, which enforces the IEC 62682 state machine rules, manages escalation timers, and persists changes to the SQLite store. No external actor can modify alert state directly.
+
+**Authentication** is handled entirely by the Signal K server. All REST API routes inherit the server's admin authentication middleware; unauthenticated requests are rejected before reaching the plugin. The plugin API has no authentication layer — any plugin running in the server process can call `app.alertManager`.
+
+## Installation
+
+### Prerequisites
+
+- **Node.js 22+** (required for built-in `node:sqlite`)
+- **Signal K server** running on Node.js 22+ with the `--experimental-sqlite` flag
+- `@signalk/server-api` v2.10.0+ (peer dependency)
+
+### Install
+
+From the Signal K Admin UI Appstore, or manually:
+
+```bash
+cd ~/.signalk
+npm install signalk-alert-manager
+```
+
+Then enable the plugin in the Signal K Admin UI under Server → Plugin Config.
+
+## Configuration
+
+All settings are optional — defaults are applied automatically.
+
+| Setting | Default | Description |
+|---|---|---|
+| **Audio: Minimum Audible Priority** | `warning` | Lowest priority that triggers browser audio. Set to `off` to disable all audio. |
+| **Silencing: Default Duration** | 120s | Maximum silence duration for non-emergency alerts |
+| **Silencing: Emergency Duration** | 30s | Maximum silence duration for emergencies |
+| **Escalation: Enabled** | `true` | Auto-escalate unacknowledged warnings to alarms |
+| **Escalation: Timeout** | 300s | Seconds before warning escalates to alarm |
+| **Source Timeout: Stale After** | 60s | Mark alert stale if source stops updating |
+| **History: Retention** | 90 days | How long to keep alert history |
+| **Dev: Enable Simulation** | `false` | Show simulation controls in the UI toolbar |
+
+Configuration is accessible through the Signal K Admin UI plugin settings page or by editing `~/.signalk/plugin-config-data/signalk-alert-manager.json`.
+
+## API Reference
+
+All endpoints are under `/plugins/signalk-alert-manager/`. Authentication is handled by Signal K server middleware.
+
+### Raise an Alert
+
+```
+POST /plugins/signalk-alert-manager/alerts
+```
+
+```bash
+curl -X POST http://localhost:3000/plugins/signalk-alert-manager/alerts \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "priority": "alarm",
+    "message": "Engine coolant temperature high",
+    "category": "engine",
+    "latching": false,
+    "data": { "path": "propulsion.main.coolantTemperature", "value": 95 }
+  }'
+```
+
+Returns `201` with the created alert object.
+
+### List Alerts
+
+```
+GET /plugins/signalk-alert-manager/alerts
+GET /plugins/signalk-alert-manager/alerts?state=unacknowledged
+GET /plugins/signalk-alert-manager/alerts?priority=alarm,emergency
+GET /plugins/signalk-alert-manager/alerts?category=engine
+GET /plugins/signalk-alert-manager/alerts?stale=true
+```
+
+### Get Single Alert
+
+```
+GET /plugins/signalk-alert-manager/alerts/{id}
+```
+
+### Acknowledge
+
+```
+POST /plugins/signalk-alert-manager/alerts/{id}/acknowledge
+```
+
+The authenticated user's identity is recorded in `acknowledgedBy`.
+
+### Silence
+
+```
+POST /plugins/signalk-alert-manager/alerts/{id}/silence
+```
+
+Optional body: `{ "duration": 30 }` (seconds). If omitted, uses the configured maximum for the alert's priority.
+
+### Silence All
+
+```
+POST /plugins/signalk-alert-manager/alerts/silence-all
+```
+
+### Clear Condition
+
+```
+PUT /plugins/signalk-alert-manager/alerts/{id}/condition
+Content-Type: application/json
+
+{ "active": false }
+```
+
+Used by sources to signal that the triggering condition has resolved.
+
+### Indication State
+
+```
+GET /plugins/signalk-alert-manager/alerts/indication
+```
+
+Returns aggregate state for driving physical alarm panels, buzzers, and displays. The `priority` field is the highest priority among unacknowledged alerts, or `null` when no unacknowledged alerts exist.
+
+```json
+{
+  "audible": true,
+  "priority": "alarm",
+  "flash": true,
+  "silenced": false,
+  "unacknowledgedCount": 3
+}
+```
+
+### Alert History
+
+```
+GET /plugins/signalk-alert-manager/alerts/history
+GET /plugins/signalk-alert-manager/alerts/history?from=2026-01-01T00:00:00Z&to=2026-01-31T23:59:59Z
+GET /plugins/signalk-alert-manager/alerts/history?alertId={id}
+GET /plugins/signalk-alert-manager/alerts/history?eventType=raise,acknowledge
+GET /plugins/signalk-alert-manager/alerts/history?limit=50&offset=100
+```
+
+Event types: `raise`, `acknowledge`, `silence`, `unsilence`, `clear`, `escalate`.
+
+### UI Configuration
+
+```
+GET /plugins/signalk-alert-manager/config/ui
+```
+
+Returns browser-relevant settings (audio threshold, simulation mode).
+
+## Plugin API
+
+Other Signal K plugins can interact with alerts programmatically via `app.alertManager`:
+
+```typescript
+// Raise an alert
+const alert = await app.alertManager.raiseAlert({
+  sourceId: 'my-plugin',
+  priority: 'warning',
+  message: 'Anchor watch: vessel outside radius',
+  category: 'navigation',
+  latching: true
+})
+
+// Acknowledge
+await app.alertManager.acknowledgeAlert(alert.id, 'operator-1')
+
+// Clear condition
+await app.alertManager.clearCondition(alert.id)
+
+// Silence for 60 seconds (plugin API takes milliseconds; REST API takes seconds)
+await app.alertManager.silenceAlert(alert.id, 60000)
+
+// Silence all audible alerts
+await app.alertManager.silenceAll()
+
+// Query alerts
+const emergencies = app.alertManager.getAlerts({ priority: 'emergency' })
+const unacked = app.alertManager.getAlerts({ state: 'unacknowledged' })
+
+// Get indication state for hardware integration
+const indication = app.alertManager.getIndicationState()
+
+// Register a reusable alert type (reserved for future use — definitions
+// are stored but not yet consumed by raiseAlert)
+app.alertManager.registerAlertType({
+  alertType: 'engine.coolant.high',
+  defaultPriority: 'alarm',
+  latching: false,
+  message: 'Engine coolant temperature high',
+  category: 'engine'
+})
+```
+
+TypeScript types are exported from the package for use in plugin development:
+
+```typescript
+import type {
+  Alert,
+  AlertPriority,
+  AlertState,
+  AlertManagerAPI,
+  RaiseAlertRequest,
+  AlertFilter,
+  IndicationState,
+  HistoryEntry
+} from 'signalk-alert-manager'
+```
+
+## Signal K Integration
+
+### Notification Interception
+
+The plugin intercepts incoming `notifications.*` deltas and transforms them into managed alerts. Signal K notification states map to alert priorities:
+
+| SK Notification State | Alert Priority |
+|---|---|
+| `emergency` | Emergency |
+| `alarm` | Alarm |
+| `warn` | Warning |
+| `alert` | Caution |
+| `normal`, `nominal` | Clears the condition |
+
+Notifications continue to flow through Signal K normally — the alert manager subscribes non-destructively via `registerDeltaInputHandler`.
+
+### Delta Publishing
+
+Alert state changes are published as Signal K deltas on `alerts.active.*` and `alerts.indication` paths, enabling real-time updates for any WebSocket-connected client.
+
+## Web UI
+
+The plugin provides a web interface accessible at the plugin's webapp URL in Signal K. Built with [Lit](https://lit.dev/) web components for framework-agnostic reuse.
+
+**Alert List** — Full alert management view with priority-sorted list, acknowledge/silence controls, and a toolbar with global silence and optional simulation controls.
+
+**Alert Detail** — Expanded view of a single alert showing full metadata, history timeline, and action controls. Accessible by selecting an alert in the list.
+
+**Alert Banner** — Compact embeddable component showing the highest-priority unacknowledged alert, designed for use in other applications (chart plotters, dashboards). Expands to show all active alerts.
+
+**Audio** — Browser-based audio alerts with different tones per priority level, respecting the configured minimum audible priority and silence state.
+
+## Development
+
+```bash
+npm run build          # Compile TypeScript (plugin backend)
+npm run build:ui       # Build UI with Vite (output to public/)
+npm run dev:ui         # Vite dev server for UI development
+npm test               # Run all Vitest tests
+npm run test:ui        # Run UI component tests
+npm run test:e2e       # Run end-to-end tests
+npm run lint           # ESLint check
+npm run format         # Prettier format
+npm run ci             # Full CI check (typecheck + lint + format + test)
+```
+
+## Standards References
+
+- [IMO MSC.302(87)](https://www.imo.org/en/OurWork/Safety/Pages/BridgeAlertManagement.aspx) — Performance Standards for Bridge Alert Management
+- [IMO A.1021(26)](https://www.imo.org/en/KnowledgeCentre/IndexofIMOResolutions/Pages/A-2009-11.aspx) — Code on Alerts and Indicators
+- IEC 62682:2023 — Management of alarm systems for the process industries
+- [OpenBridge Design System](https://www.openbridge.no/) — Maritime UI design guidelines
+- [Signal K Specification](https://signalk.org/specification/) — Signal K data model and notification schema
+- [signalk-server#1857](https://github.com/SignalK/signalk-server/issues/1857) — Discussion on alert data model and lifecycle
 
 ## License
 
-Apache License 2.0 - see [LICENSE](LICENSE)
+Apache License 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Replace stub README with full documentation: motivation section comparing with Signal K notifications (based on actual server code analysis), alert model explanation, API reference with curl examples, plugin API guide, configuration table, and development commands
- Add initial CHANGELOG for v0.1.0
- Update AGENTS.md to reflect actual implementation (Lit web components, Vitest, correct file structure, config schema reference)

Closes #24

## Test plan

- [x] `npm run ci` passes (414 tests, typecheck, lint, format all green)
- [ ] Review README accuracy against actual API endpoints and config schema
- [ ] Verify Signal K notification comparison is factually accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)