### PR TITLE
Centralize silencing cleanup in AlertManager

### DIFF
--- a/src/core/AlertManager.ts
+++ b/src/core/AlertManager.ts
@@ -260,12 +260,8 @@ export class AlertManager extends EventEmitter {
     const result = this.stateMachine.acknowledge(alert, userId)
 
     this.escalationTimer.cancelTimer(alertId)
-    this.cancelSilenceExpirationTimer(alertId)
-    // Silencing is superseded by acknowledge — clear flags without emitting
-    // a separate 'unsilenced' event, since the 'acknowledged' event already
-    // conveys that the operator has attended to the alert.
-    if (result.alert?.silenced) {
-      result.alert = this.stateMachine.unsilence(result.alert)
+    if (result.alert) {
+      result.alert = this.clearSilencingIfSuperseded(alertId, result.alert)
     }
 
     if (result.cleared) {
@@ -330,15 +326,7 @@ export class AlertManager extends EventEmitter {
     // is re-alerted at the new (higher) priority.
     const reactivation = this.stateMachine.reactivate(priorityUpdated)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- reactivate() never clears
-    let updated = reactivation.alert!
-
-    // Clear silence on escalation: a higher priority demands operator attention.
-    // reactivate() handles this for acknowledged/rtn-unacknowledged, but not
-    // for unacknowledged+silenced alerts.
-    if (updated.silenced) {
-      updated = { ...updated, silenced: false, silencedUntil: undefined }
-    }
-    this.cancelSilenceExpirationTimer(alertId)
+    const updated = this.clearSilencingIfSuperseded(alertId, reactivation.alert!)
 
     this.alerts.set(alertId, updated)
     if (this.store) {
@@ -683,7 +671,7 @@ export class AlertManager extends EventEmitter {
     // Attempt to reactivate (acknowledged/rtn-unacknowledged → unacknowledged)
     const reactivation = this.stateMachine.reactivate(dataUpdated)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- reactivate() never clears
-    const updated = reactivation.alert!
+    const updated = this.clearSilencingIfSuperseded(existing.id, reactivation.alert!)
     const stateChanged = reactivation.previousState !== updated.state
 
     this.alerts.set(existing.id, updated)
@@ -700,8 +688,7 @@ export class AlertManager extends EventEmitter {
     }
 
     if (stateChanged) {
-      // Reactivation: cancel silence timer, restart escalation, log and emit 'raised'
-      this.cancelSilenceExpirationTimer(existing.id)
+      // Reactivation: restart escalation, log and emit 'raised'
       this.escalationTimer.cancelTimer(existing.id)
       this.escalationTimer.startTimer(existing.id, updated.priority)
 
@@ -798,6 +785,27 @@ export class AlertManager extends EventEmitter {
     }
 
     this.emit('alert', event)
+  }
+
+  /**
+   * Clear silencing if the current operation supersedes it.
+   *
+   * Silencing suppresses audio — it is superseded when the operator has
+   * attended to the alert (acknowledge) or when the system demands renewed
+   * attention (reactivation, escalation). This is the single place that
+   * encodes that rule, replacing previously scattered cleanup in
+   * acknowledgeAlert, escalateAlert, and updateExistingAlert.
+   *
+   * Does not emit a separate 'unsilenced' event because the caller's own
+   * event (acknowledged, escalated, raised) already conveys that the
+   * operator's attention has been (re)demanded.
+   */
+  private clearSilencingIfSuperseded(alertId: string, alert: Alert): Alert {
+    if (!alert.silenced) {
+      return alert
+    }
+    this.cancelSilenceExpirationTimer(alertId)
+    return this.stateMachine.unsilence(alert)
   }
 
   /**

--- a/src/core/AlertStateMachine.ts
+++ b/src/core/AlertStateMachine.ts
@@ -294,9 +294,13 @@ export class AlertStateMachine {
    * (or again) active. Transitions the alert back to unacknowledged so
    * the operator is re-alerted.
    *
+   * Silencing is NOT cleared here — that responsibility belongs to
+   * AlertManager, which also manages the silence expiration timers.
+   * See AlertManager.clearSilencingIfSuperseded().
+   *
    * Transitions:
-   * - acknowledged → unacknowledged (resets ack fields, silencing)
-   * - rtn-unacknowledged → unacknowledged (resets clearedAt, silencing)
+   * - acknowledged → unacknowledged (resets ack fields)
+   * - rtn-unacknowledged → unacknowledged (resets clearedAt)
    * - unacknowledged → unacknowledged (idempotent, ensures condition=true)
    */
   reactivate(alert: Alert): StateTransitionResult {
@@ -309,9 +313,7 @@ export class AlertStateMachine {
           state: 'unacknowledged',
           condition: true,
           acknowledgedAt: undefined,
-          acknowledgedBy: undefined,
-          silenced: false,
-          silencedUntil: undefined
+          acknowledgedBy: undefined
         },
         cleared: false,
         previousState
@@ -324,9 +326,7 @@ export class AlertStateMachine {
           ...alert,
           state: 'unacknowledged',
           condition: true,
-          clearedAt: undefined,
-          silenced: false,
-          silencedUntil: undefined
+          clearedAt: undefined
         },
         cleared: false,
         previousState

--- a/test/core/AlertManager.test.ts
+++ b/test/core/AlertManager.test.ts
@@ -2255,6 +2255,38 @@ describe('AlertManager', () => {
       expect(events.filter((e) => e.type === 'unsilenced')).toHaveLength(0)
     })
 
+    it('should un-silence on idempotent re-raise of unacknowledged alert', async () => {
+      const alert = await manager.raiseAlert({
+        path: 'test.alert',
+        $source: 'test-source',
+        priority: 'alarm',
+        message: 'Test alert'
+      })
+
+      // Silence without acknowledging first
+      await manager.silenceAlert(alert.id, 30000)
+      expect(manager.getAlert(alert.id)?.silenced).toBe(true)
+      expect(manager.getAlert(alert.id)?.state).toBe('unacknowledged')
+
+      // Re-raise the same alert (idempotent reactivation)
+      await manager.raiseAlert({
+        path: 'test.alert',
+        $source: 'test-source',
+        priority: 'alarm',
+        message: 'Test alert re-raised'
+      })
+
+      const reactivated = manager.getAlert(alert.id)
+      expect(reactivated?.state).toBe('unacknowledged')
+      expect(reactivated?.silenced).toBe(false)
+      expect(reactivated?.silencedUntil).toBeUndefined()
+
+      // Silence timer should not fire (was cancelled)
+      events = []
+      fakeTimers.advanceTime(30000)
+      expect(events.filter((e) => e.type === 'unsilenced')).toHaveLength(0)
+    })
+
     it('should preserve raisedAt on reactivation', async () => {
       const alert = await manager.raiseAlert({
         path: 'test.alert',

--- a/test/core/AlertStateMachine.test.ts
+++ b/test/core/AlertStateMachine.test.ts
@@ -507,15 +507,18 @@ describe('AlertStateMachine', () => {
       expect(result.alert?.condition).toBe(true)
     })
 
-    it('should reset silenced and silencedUntil on reactivation', () => {
+    it('should preserve silencing on reactivation (AlertManager clears it)', () => {
       const alert = makeAlert()
       const acked = assertAlert(stateMachine.acknowledge(alert).alert)
       const silenced = stateMachine.silence(acked, new Date(Date.now() + 30000))
 
       const result = stateMachine.reactivate(silenced)
 
-      expect(result.alert?.silenced).toBe(false)
-      expect(result.alert?.silencedUntil).toBeUndefined()
+      // Silencing is NOT cleared by the state machine — that responsibility
+      // belongs to AlertManager.clearSilencingIfSuperseded(), which also
+      // manages the silence expiration timers.
+      expect(result.alert?.silenced).toBe(true)
+      expect(result.alert?.silencedUntil).toBeDefined()
     })
 
     it('should transition latching acknowledged to unacknowledged', () => {


### PR DESCRIPTION
## Summary

- Extract `clearSilencingIfSuperseded()` as the single place that clears silencing flags and cancels expiration timers, replacing scattered manual cleanup in `acknowledgeAlert()`, `escalateAlert()`, and `updateExistingAlert()`
- Move silencing cleanup out of `AlertStateMachine.reactivate()` into AlertManager, where timer management lives
- Fix bug: idempotent reactivation of an unacknowledged+silenced alert (re-raise while already unacknowledged) now correctly clears silencing

## Test plan

- [ ] All 475 existing tests pass
- [ ] New test: `should un-silence on idempotent re-raise of unacknowledged alert` covers the previously buggy path
- [ ] StateMachine test updated to verify `reactivate()` no longer touches silencing (responsibility boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)