### PR TITLE
Add SK PUT handlers for readwrite-authenticated devices

### DIFF
--- a/src/api/putHandlers.ts
+++ b/src/api/putHandlers.ts
@@ -1,0 +1,130 @@
+/**
+ * Signal K PUT Handlers
+ *
+ * Registers PUT handlers for alert actions on the Signal K data model.
+ * This provides an alternative to the REST API that works with readwrite
+ * auth tokens (the REST API under /plugins requires admin auth).
+ *
+ * PUT handlers are the standard Signal K mechanism for plugins to expose
+ * actions. They work over both HTTP PUT to /signalk/v1/api/vessels/self/<path>
+ * and WebSocket PUT messages.
+ *
+ * @see https://signalk.org/specification/ for PUT handler documentation
+ */
+
+import type { ActionHandler, ActionResult, ServerAPI } from '@signalk/server-api'
+import type { AlertManager } from '../core/AlertManager.js'
+import type { AlertPriority } from '../types.js'
+
+const VALID_PRIORITIES: AlertPriority[] = ['emergency', 'alarm', 'warning', 'caution']
+
+interface PutHandlerDependencies {
+  getAlertManager(): AlertManager | undefined
+}
+
+function managerOrFail(deps: PutHandlerDependencies): AlertManager {
+  const mgr = deps.getAlertManager()
+  if (!mgr) {
+    throw new Error('Alert manager not initialized')
+  }
+  return mgr
+}
+
+function extractId(value: unknown): string {
+  if (typeof value !== 'object' || value === null || !('id' in value)) {
+    throw new Error('Missing required field: id')
+  }
+  const id = (value as Record<string, unknown>).id
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error('Field id must be a non-empty string')
+  }
+  return id
+}
+
+function completed(statusCode: number, message?: string): ActionResult {
+  return { state: 'COMPLETED', statusCode, message }
+}
+
+function makeAsyncHandler(
+  deps: PutHandlerDependencies,
+  fn: (mgr: AlertManager, value: unknown) => Promise<void>
+): ActionHandler {
+  return (_context: string, _path: string, value: unknown, callback) => {
+    try {
+      const mgr = managerOrFail(deps)
+      fn(mgr, value)
+        .then(() => {
+          callback(completed(200))
+        })
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err)
+          callback(completed(400, message))
+        })
+      return { state: 'PENDING' }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return completed(400, message)
+    }
+  }
+}
+
+/**
+ * Register Signal K PUT handlers for all alert actions.
+ *
+ * Handlers are automatically cleaned up when the plugin stops
+ * (the SK framework tracks registrations per plugin).
+ */
+export function registerPutHandlers(app: ServerAPI, deps: PutHandlerDependencies): void {
+  const context = 'vessels.self'
+
+  app.registerPutHandler(
+    context,
+    'alerts.actions.silenceAll',
+    makeAsyncHandler(deps, async (mgr) => {
+      await mgr.silenceAll()
+    })
+  )
+
+  app.registerPutHandler(
+    context,
+    'alerts.actions.silence',
+    makeAsyncHandler(deps, async (mgr, value) => {
+      const id = extractId(value)
+      await mgr.silenceAlert(id)
+    })
+  )
+
+  app.registerPutHandler(
+    context,
+    'alerts.actions.acknowledge',
+    makeAsyncHandler(deps, async (mgr, value) => {
+      const id = extractId(value)
+      await mgr.acknowledgeAlert(id)
+    })
+  )
+
+  app.registerPutHandler(
+    context,
+    'alerts.actions.clearCondition',
+    makeAsyncHandler(deps, async (mgr, value) => {
+      const id = extractId(value)
+      await mgr.clearCondition(id)
+    })
+  )
+
+  app.registerPutHandler(
+    context,
+    'alerts.actions.escalate',
+    makeAsyncHandler(deps, async (mgr, value) => {
+      const id = extractId(value)
+      if (typeof value !== 'object' || value === null || !('priority' in value)) {
+        throw new Error('Missing required field: priority')
+      }
+      const priority = (value as Record<string, unknown>).priority
+      if (!VALID_PRIORITIES.includes(priority as AlertPriority)) {
+        throw new Error(`Invalid priority: ${String(priority)}`)
+      }
+      await mgr.escalateAlert(id, priority as AlertPriority)
+    })
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { NotificationTransformer } from './integration/NotificationTransformer.j
 import { AlertDeltaTransformer } from './integration/AlertDeltaTransformer.js'
 import { DeltaPublisher } from './integration/DeltaPublisher.js'
 import { registerRoutes } from './api/routes.js'
+import { registerPutHandlers } from './api/putHandlers.js'
 import openApi from './api/openApi.json' with { type: 'json' }
 
 // Export all types for use by other plugins and clients
@@ -276,6 +277,8 @@ export default function createPlugin(app: ServerAPI): AlertManagerPlugin {
         })
         pub.start()
         publisher = pub
+
+        registerPutHandlers(app, { getAlertManager: () => manager })
 
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (!started) {

--- a/src/test/MockServerAPI.ts
+++ b/src/test/MockServerAPI.ts
@@ -172,6 +172,14 @@ export class MockServerAPI {
     this.deltaInputHandlers.push(handler)
   }
 
+  /**
+   * Register a PUT handler for a Signal K path (no-op in mock).
+   */
+  registerPutHandler(_context: string, _path: string, _callback: unknown, _source?: string): void {
+    // No-op — PUT handler registration is not exercised in unit tests.
+    // See test/api/putHandlers.test.ts for dedicated PUT handler tests.
+  }
+
   // =========================================================================
   // Path Data Access
   // =========================================================================

--- a/test/api/putHandlers.test.ts
+++ b/test/api/putHandlers.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Signal K PUT Handler Tests
+ *
+ * Tests for PUT handlers that expose alert actions via the SK data model.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { ActionHandler, ActionResult, ServerAPI } from '@signalk/server-api'
+import { AlertManager, type AlertManagerConfig } from '../../src/core/AlertManager.js'
+import { registerPutHandlers } from '../../src/api/putHandlers.js'
+
+const DEFAULT_CONFIG: AlertManagerConfig = {
+  escalation: { enabled: false, timeoutSeconds: 300 },
+  silencing: { defaultMaxSilenceSeconds: 120, emergencyMaxSilenceSeconds: 30 },
+  sourceTimeout: { markStaleAfterSeconds: 60 },
+  retentionDays: 90
+}
+
+/**
+ * Captures registered PUT handlers for testing.
+ */
+function createMockApp(): {
+  app: Pick<ServerAPI, 'registerPutHandler'>
+  handlers: Map<string, ActionHandler>
+} {
+  const handlers = new Map<string, ActionHandler>()
+  const app = {
+    registerPutHandler: (_context: string, path: string, callback: ActionHandler) => {
+      handlers.set(path, callback)
+    }
+  }
+  return { app: app as unknown as ServerAPI, handlers }
+}
+
+function callHandler(
+  handler: ActionHandler,
+  value: unknown
+): ActionResult | { state: 'PENDING'; callback: Promise<ActionResult> } {
+  let resolveCallback: ((r: ActionResult) => void) | undefined
+  const callbackPromise = new Promise<ActionResult>((resolve) => {
+    resolveCallback = resolve
+  })
+
+  const result = handler('vessels.self', 'test.path', value, (r: ActionResult) => {
+    resolveCallback?.(r)
+  })
+
+  if (result.state === 'PENDING') {
+    return { state: 'PENDING', callback: callbackPromise }
+  }
+  return result
+}
+
+async function callAsyncHandler(handler: ActionHandler, value: unknown): Promise<ActionResult> {
+  const result = callHandler(handler, value)
+  if ('callback' in result) {
+    return result.callback
+  }
+  return result
+}
+
+function getHandler(handlers: Map<string, ActionHandler>, path: string): ActionHandler {
+  const handler = handlers.get(path)
+  if (!handler) {
+    throw new Error(`Handler not found for path: ${path}`)
+  }
+  return handler
+}
+
+describe('PUT Handlers', () => {
+  let manager: AlertManager
+  let handlers: Map<string, ActionHandler>
+
+  beforeEach(() => {
+    manager = new AlertManager(DEFAULT_CONFIG)
+    const { app, handlers: h } = createMockApp()
+    handlers = h
+    registerPutHandlers(app, { getAlertManager: () => manager })
+  })
+
+  afterEach(() => {
+    manager.stop()
+  })
+
+  it('should register all expected handlers', () => {
+    expect(handlers.has('alerts.actions.silenceAll')).toBe(true)
+    expect(handlers.has('alerts.actions.silence')).toBe(true)
+    expect(handlers.has('alerts.actions.acknowledge')).toBe(true)
+    expect(handlers.has('alerts.actions.clearCondition')).toBe(true)
+    expect(handlers.has('alerts.actions.escalate')).toBe(true)
+  })
+
+  describe('silenceAll', () => {
+    it('should silence all unacknowledged alerts', async () => {
+      const alert1 = await manager.raiseAlert({
+        path: 'test.alert1',
+        $source: 'test',
+        priority: 'alarm',
+        message: 'Alert 1'
+      })
+      const alert2 = await manager.raiseAlert({
+        path: 'test.alert2',
+        $source: 'test',
+        priority: 'warning',
+        message: 'Alert 2'
+      })
+
+      const handler = getHandler(handlers, 'alerts.actions.silenceAll')
+      const result = await callAsyncHandler(handler, {})
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(200)
+      expect(manager.getAlert(alert1.id)?.silenced).toBe(true)
+      expect(manager.getAlert(alert2.id)?.silenced).toBe(true)
+    })
+
+    it('should succeed even with no alerts', async () => {
+      const handler = getHandler(handlers, 'alerts.actions.silenceAll')
+      const result = await callAsyncHandler(handler, {})
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(200)
+    })
+  })
+
+  describe('silence', () => {
+    it('should silence a specific alert', async () => {
+      const alert = await manager.raiseAlert({
+        path: 'test.alert',
+        $source: 'test',
+        priority: 'alarm',
+        message: 'Test alert'
+      })
+
+      const handler = getHandler(handlers, 'alerts.actions.silence')
+      const result = await callAsyncHandler(handler, { id: alert.id })
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(200)
+      expect(manager.getAlert(alert.id)?.silenced).toBe(true)
+    })
+
+    it('should return 400 for missing id', async () => {
+      const handler = getHandler(handlers, 'alerts.actions.silence')
+      const result = await callAsyncHandler(handler, {})
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(400)
+      expect(result.message).toContain('id')
+    })
+
+    it('should return 400 for non-existent alert', async () => {
+      const handler = getHandler(handlers, 'alerts.actions.silence')
+      const result = await callAsyncHandler(handler, { id: 'non-existent' })
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(400)
+      expect(result.message).toContain('not found')
+    })
+  })
+
+  describe('acknowledge', () => {
+    it('should acknowledge a specific alert', async () => {
+      const alert = await manager.raiseAlert({
+        path: 'test.alert',
+        $source: 'test',
+        priority: 'alarm',
+        message: 'Test alert'
+      })
+
+      const handler = getHandler(handlers, 'alerts.actions.acknowledge')
+      const result = await callAsyncHandler(handler, { id: alert.id })
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(200)
+      expect(manager.getAlert(alert.id)?.state).toBe('acknowledged')
+    })
+
+    it('should return 400 for missing id', async () => {
+      const handler = getHandler(handlers, 'alerts.actions.acknowledge')
+      const result = await callAsyncHandler(handler, { id: '' })
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(400)
+    })
+  })
+
+  describe('clearCondition', () => {
+    it('should clear condition on a specific alert', async () => {
+      const alert = await manager.raiseAlert({
+        path: 'test.alert',
+        $source: 'test',
+        priority: 'alarm',
+        message: 'Test alert'
+      })
+
+      const handler = getHandler(handlers, 'alerts.actions.clearCondition')
+      const result = await callAsyncHandler(handler, { id: alert.id })
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(200)
+      // Alarm priority requires ack, so clearing goes to rtn-unacknowledged
+      expect(manager.getAlert(alert.id)?.state).toBe('rtn-unacknowledged')
+    })
+  })
+
+  describe('escalate', () => {
+    it('should escalate a specific alert', async () => {
+      const alert = await manager.raiseAlert({
+        path: 'test.alert',
+        $source: 'test',
+        priority: 'warning',
+        message: 'Test alert'
+      })
+
+      const handler = getHandler(handlers, 'alerts.actions.escalate')
+      const result = await callAsyncHandler(handler, {
+        id: alert.id,
+        priority: 'alarm'
+      })
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(200)
+      expect(manager.getAlert(alert.id)?.priority).toBe('alarm')
+    })
+
+    it('should return 400 for missing priority', async () => {
+      const alert = await manager.raiseAlert({
+        path: 'test.alert',
+        $source: 'test',
+        priority: 'warning',
+        message: 'Test alert'
+      })
+
+      const handler = getHandler(handlers, 'alerts.actions.escalate')
+      const result = await callAsyncHandler(handler, { id: alert.id })
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(400)
+      expect(result.message).toContain('priority')
+    })
+
+    it('should return 400 for invalid priority', async () => {
+      const alert = await manager.raiseAlert({
+        path: 'test.alert',
+        $source: 'test',
+        priority: 'warning',
+        message: 'Test alert'
+      })
+
+      const handler = getHandler(handlers, 'alerts.actions.escalate')
+      const result = await callAsyncHandler(handler, {
+        id: alert.id,
+        priority: 'invalid'
+      })
+
+      expect(result.state).toBe('COMPLETED')
+      expect(result.statusCode).toBe(400)
+      expect(result.message).toContain('Invalid priority')
+    })
+  })
+
+  describe('uninitialized manager', () => {
+    it('should return 400 when manager is not initialized', () => {
+      const { app: mockApp, handlers: uninitHandlers } = createMockApp()
+      registerPutHandlers(mockApp, { getAlertManager: () => undefined })
+
+      const handler = getHandler(uninitHandlers, 'alerts.actions.silenceAll')
+      const result = callHandler(handler, {})
+
+      expect(result.state).toBe('COMPLETED')
+      expect((result as ActionResult).statusCode).toBe(400)
+      expect((result as ActionResult).message).toContain('not initialized')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Register PUT handlers via `app.registerPutHandler()` for all alert actions, accessible with `readwrite` auth tokens
- Paths: `alerts.actions.{silenceAll,silence,acknowledge,clearCondition,escalate}`
- Works over both HTTP PUT to `/signalk/v1/api/vessels/self/<path>` and WebSocket PUT messages
- Existing REST API under `/plugins/` unchanged (still requires admin)

## Motivation

All `/plugins/*` routes require admin auth (server-level policy in `tokensecurity.ts`). SensESP devices and other SK clients authenticate via the access request flow, which grants `readwrite` JWT tokens. These tokens are rejected on plugin REST endpoints.

`registerPutHandler` is the standard SK mechanism for plugins to expose actions — it uses `shouldAllowPut()` which allows `readwrite` tokens. This is an interim solution; a server-side change to support `readwrite`-level plugin routes is tracked as SignalK/signalk-server#2587.

## Test plan

- [ ] 13 new unit tests covering all handlers (success, validation, error paths)
- [ ] All 488 tests pass
- [ ] Deploy to test device and verify with readwrite token via curl
- [ ] Verify WebSocket PUT from SensESP device

🤖 Generated with [Claude Code](https://claude.com/claude-code)