### PR TITLE
Fix installation instructions for unpublished package

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,20 @@ Each alert is identified by its `path` (with optional `context` for multi-vessel
 
 ### Install
 
-From the Signal K Admin UI Appstore, or manually:
-
 ```bash
 cd ~/.signalk
-npm install signalk-alert-manager
+npm install https://github.com/hatlabs/signalk-alert-manager/tarball/main
+```
+
+Then enable the plugin in the Signal K Admin UI under Server → Plugin Config.
+
+### Install on HaLOS
+
+On HaLOS, Signal K runs in a Docker container. Install the plugin and restart the service:
+
+```bash
+sudo docker exec signalk-server npm install https://github.com/hatlabs/signalk-alert-manager/tarball/main --prefix /home/node/.signalk
+sudo systemctl restart marine-signalk-server-container.service
 ```
 
 Then enable the plugin in the Signal K Admin UI under Server → Plugin Config.


### PR DESCRIPTION
## Summary
- Install from GitHub tarball URL instead of NPM (package not published yet)
- Add HaLOS-specific install instructions for containerized Signal K
- Remove Appstore reference

## Test plan
- [x] Tested `sudo docker exec` install command on HaLOS device — works

🤖 Generated with [Claude Code](https://claude.com/claude-code)