### PR TITLE
Update install instructions to use npm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,23 +109,23 @@ Each alert is identified by its `path` (with optional `context` for multi-vessel
 
 ### Install
 
+Install from the Signal K Appstore (Server → Appstore in the Admin UI), then enable the plugin under Server → Plugin Config.
+
+#### Manual install
+
 ```bash
 cd ~/.signalk
 npm install signalk-alert-manager
 ```
 
-Then enable the plugin in the Signal K Admin UI under Server → Plugin Config.
+#### Manual install on HaLOS
 
-### Install on HaLOS
-
-On HaLOS, Signal K runs in a Docker container. Install the plugin and restart the service:
+On HaLOS, Signal K runs in a Docker container:
 
 ```bash
 sudo docker exec signalk-server npm install signalk-alert-manager --prefix /home/node/.signalk
 sudo systemctl restart marine-signalk-server-container.service
 ```
-
-Then enable the plugin in the Signal K Admin UI under Server → Plugin Config.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Each alert is identified by its `path` (with optional `context` for multi-vessel
 
 ```bash
 cd ~/.signalk
-npm install https://github.com/hatlabs/signalk-alert-manager/tarball/main
+npm install signalk-alert-manager
 ```
 
 Then enable the plugin in the Signal K Admin UI under Server → Plugin Config.
@@ -121,7 +121,7 @@ Then enable the plugin in the Signal K Admin UI under Server → Plugin Config.
 On HaLOS, Signal K runs in a Docker container. Install the plugin and restart the service:
 
 ```bash
-sudo docker exec signalk-server npm install https://github.com/hatlabs/signalk-alert-manager/tarball/main --prefix /home/node/.signalk
+sudo docker exec signalk-server npm install signalk-alert-manager --prefix /home/node/.signalk
 sudo systemctl restart marine-signalk-server-container.service
 ```
 


### PR DESCRIPTION
## Summary

- Replace GitHub tarball URLs with `npm install signalk-alert-manager` now that the package is published to npm

## Test plan

- [ ] Verify `npm install signalk-alert-manager` works in a clean Signal K instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)