### PR TITLE
docs: refresh and reposition the notifications-vs-alerts comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,31 @@ Signal K server plugin for centralized alert management following maritime and p
 
 ## Why This Plugin?
 
-Signal K has no built-in alert management. Maritime safety standards (IMO MSC.302(87), IEC 62682) require features that simply don't exist in the server: alert lifecycle tracking, operator acknowledgment, persistence across restarts, silencing, escalation, and audit trails.
+Signal K's server includes a Notifications API that assigns each notification an ID and can raise, acknowledge, and silence it. What it doesn't provide is the alert management maritime safety standards (IMO MSC.302(87), IEC 62682) require: a formal lifecycle state machine with return-to-normal handling, persistence across restarts, automatic escalation, source-liveness tracking, and an audit trail.
 
 signalk-alert-manager provides a standalone alert management system based on these standards. Alerts can be raised through multiple paths — a REST API, a plugin API for other Signal K plugins, incoming `alerts.*` deltas from devices, or automatically from existing `notifications.*` deltas — and all alerts receive the same lifecycle management regardless of how they entered the system.
 
 ### Relationship to Signal K Notifications
 
-Signal K's `notifications.*` paths provide a simple signaling layer — a value at a path with a state and message. They were not designed for alert management and lack lifecycle, acknowledgment, persistence, and history. The alert manager is a separate system that can *ingest* notifications as one alert source among others, not a replacement or extension of the notification mechanism.
+Signal K's `notifications.*` paths provide a signaling layer — a value at a path with a state and message — and the server's Notifications API layers basic lifecycle on top: a per-notification ID, acknowledge and silence actions, and reactivation when severity changes. It still lacks the standards-based alert management this plugin targets: a formal IEC 62682 state machine with return-to-normal, persistence, escalation, history, and source-liveness tracking. The alert manager is a separate system that can *ingest* notifications as one alert source among others, not a replacement or extension of the notification mechanism.
 
 The comparison below summarizes the differences:
 
 | Capability | Signal K Notifications | Alert Manager |
 |---|---|---|
-| Data model | Key-value at `notifications.*` paths | Alert objects with unique IDs, full metadata |
-| States | `normal`, `nominal`, `alert`, `warn`, `alarm`, `emergency` | IEC 62682: unacknowledged, acknowledged, return-to-normal |
-| Lifecycle | None — value replaced on update | Raise → acknowledge → clear with full tracking |
-| Acknowledgment | Not supported | Per-alert, records who and when |
-| Silencing | Not supported | Time-limited, configurable per priority |
+| Data model | `notifications.*` values, each with a per-notification ID and silence/ack status | Alert objects with unique IDs, full metadata |
+| States | `normal`, `nominal`, `alert`, `warn`, `alarm`, `emergency` (severity) | IEC 62682 lifecycle: unacknowledged, acknowledged, return-to-normal |
+| Lifecycle | Basic — acknowledge, silence, clear, and reactivation on severity change | Full IEC 62682 state machine with return-to-normal tracking |
+| Acknowledgment | Supported (status flag, no operator identity) | Per-alert, records who and when |
+| Silencing | Supported (no timeout) | Time-limited, configurable per priority |
 | Escalation | Not supported | Automatic priority promotion on timeout |
 | Persistence | In-memory only (lost on restart) | SQLite — survives restarts |
 | History | None | Full audit trail with query API |
 | Source tracking | `$source` field | Source liveness monitoring, stale detection |
-| Priority model | Implicit in state string | Four explicit levels (IMO model) with defined behaviors |
-| Creation | Zone triggers or manual deltas | REST API, plugin API, `alerts.*` deltas, and notification ingestion |
+| Priority model | Same as the severity `state` — one dimension, no separate axis | Separate axis from lifecycle state, with defined per-level behavior |
+| Creation | Zone triggers, manual deltas, or the Notifications API (REST/plugin) | REST API, plugin API, `alerts.*` deltas, and notification ingestion |
+
+> **Priority model** here means how urgency is *represented*, not whether it exists. Notifications fold urgency into the `state` value, so the severity levels (`alert`/`warn`/`alarm`/`emergency`) and the field that changes over the notification's life are one and the same. The alert manager keeps priority as a separate axis from lifecycle state — an alert holds its priority while moving through the lifecycle — and attaches behavior to each level (audible pattern, acknowledgment requirement, escalation eligibility). See [Priority Levels](#priority-levels).
 
 ## Alert Model
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # signalk-alert-manager
 
-Signal K server plugin for centralized alert management following maritime and process industry standards.
+Signal K server plugin for centralized alert management following the IMO bridge alert management standards (MSC.302(87) / IEC 62923).
 
 ## Why This Plugin?
 
-Signal K's server includes a Notifications API that assigns each notification an ID and can raise, acknowledge, and silence it. What it doesn't provide is the alert management maritime safety standards (IMO MSC.302(87), IEC 62682) require: a formal lifecycle state machine with return-to-normal handling, persistence across restarts, automatic escalation, source-liveness tracking, and an audit trail.
+Signal K's server includes a Notifications API that assigns each notification an ID and can raise, acknowledge, and silence it. What it doesn't provide is the alert management the IMO bridge alert management standards (MSC.302(87), realized in IEC 62923) call for: a formal lifecycle state machine with return-to-normal handling, persistence across restarts, automatic escalation, source-liveness tracking, and an audit trail.
 
 signalk-alert-manager provides a standalone alert management system based on these standards. Alerts can be raised through multiple paths — a REST API, a plugin API for other Signal K plugins, incoming `alerts.*` deltas from devices, or automatically from existing `notifications.*` deltas — and all alerts receive the same lifecycle management regardless of how they entered the system.
 
 ### Relationship to Signal K Notifications
 
-Signal K's `notifications.*` paths provide a signaling layer — a value at a path with a state and message — and the server's Notifications API layers basic lifecycle on top: a per-notification ID, acknowledge and silence actions, and reactivation when severity changes. It still lacks the standards-based alert management this plugin targets: a formal IEC 62682 state machine with return-to-normal, persistence, escalation, history, and source-liveness tracking. The alert manager is a separate system that can *ingest* notifications as one alert source among others, not a replacement or extension of the notification mechanism.
+Signal K's `notifications.*` paths provide a signaling layer — a value at a path with a state and message — and the server's Notifications API layers basic lifecycle on top: a per-notification ID, acknowledge and silence actions, and reactivation when severity changes. It still lacks the standards-based alert management this plugin targets: a formal alert lifecycle state machine with return-to-normal, persistence, escalation, history, and source-liveness tracking. The alert manager is a separate system that can *ingest* notifications as one alert source among others, not a replacement or extension of the notification mechanism.
 
 The comparison below summarizes the differences:
 
 | Capability | Signal K Notifications | Alert Manager |
 |---|---|---|
 | Data model | `notifications.*` values, each with a per-notification ID and silence/ack status | Alert objects with unique IDs, full metadata |
-| States | `normal`, `nominal`, `alert`, `warn`, `alarm`, `emergency` (severity) | IEC 62682 lifecycle: unacknowledged, acknowledged, return-to-normal |
-| Lifecycle | Basic — acknowledge, silence, clear, and reactivation on severity change | Full IEC 62682 state machine with return-to-normal tracking |
+| States | `normal`, `nominal`, `alert`, `warn`, `alarm`, `emergency` (severity) | IEC 62923 lifecycle: unacknowledged, acknowledged, return-to-normal |
+| Lifecycle | Basic — acknowledge, silence, clear, and reactivation on severity change | Full IEC 62923 four-state lifecycle with return-to-normal tracking |
 | Acknowledgment | Supported (status flag, no operator identity) | Per-alert, records who and when |
 | Silencing | Supported (no timeout) | Time-limited, configurable per priority |
 | Escalation | Not supported | Automatic priority promotion on timeout |
@@ -43,11 +43,11 @@ Four priority levels follow the IMO model, from most to least urgent:
 | **Warning** | Conditions requiring precautionary attention | 2-pulse chime, repeating | Yes |
 | **Caution** | Noteworthy conditions, not immediately hazardous | None | No |
 
-All audible patterns repeat until the alert is acknowledged or silenced. Each priority has a distinct frequency (880/660/440 Hz) and pulse pattern inspired by IEC 60601-1-8.
+All audible patterns repeat until the alert is acknowledged or silenced. Each priority has a distinct frequency (880/660/440 Hz) and pulse pattern adapted from IEC 60601-1-8 (a medical-alarm ergonomics standard, borrowed for its tested priority-distinguishable tones — not a marine reference).
 
 ### Alert Lifecycle
 
-Alerts follow the IEC 62682 state model:
+Alerts follow the IEC 62923 four-state alert lifecycle:
 
 ```
                  condition                    condition clears
@@ -67,7 +67,7 @@ Caution-priority alerts skip acknowledgment — they clear automatically when th
 
 ### Latching
 
-Some alerts represent one-shot events (e.g., waypoint arrival, anchor drag detected) where the triggering condition is momentary. Latching alerts remain active after the condition clears and must be explicitly acknowledged to dismiss.
+Some alerts represent one-shot events (e.g., waypoint arrival, anchor drag detected) where the triggering condition is momentary. Latching alerts remain active after the condition clears and must be explicitly acknowledged to dismiss. (Latching is borrowed from IEC 62682; marine BAM does not define it.)
 
 ### Silencing
 
@@ -97,7 +97,7 @@ Each alert is identified by its `path` (with optional `context` for multi-vessel
 
 **Who can acknowledge, silence, and clear?** Any authenticated user can perform any operation on any alert, regardless of who raised it. There is no per-alert ownership or role-based restriction. This is intentional: in a bridge context, any watchkeeper must be able to respond to any alert immediately. The operator's identity is recorded for audit purposes (in `acknowledgedBy` and in the history log) but is not used for access control.
 
-**Who manages alert state?** The `AlertManager` is the single source of truth. All state transitions — whether triggered by the REST API, the plugin API, or the notification transformer — pass through the AlertManager, which enforces the IEC 62682 state machine rules, manages escalation timers, and persists changes to the SQLite store. No external actor can modify alert state directly.
+**Who manages alert state?** The `AlertManager` is the single source of truth. All state transitions — whether triggered by the REST API, the plugin API, or the notification transformer — pass through the AlertManager, which enforces the alert lifecycle state-machine rules, manages escalation timers, and persists changes to the SQLite store. No external actor can modify alert state directly.
 
 **Authentication** is handled entirely by the Signal K server. All REST API routes inherit the server's admin authentication middleware; unauthenticated requests are rejected before reaching the plugin. The plugin API has no authentication layer — any plugin running in the server process can call `app.alertManager`.
 
@@ -461,7 +461,8 @@ npm run ci             # Full CI check (typecheck + lint + format + test)
 
 - [IMO MSC.302(87)](https://www.imo.org/en/OurWork/Safety/Pages/BridgeAlertManagement.aspx) — Performance Standards for Bridge Alert Management
 - [IMO A.1021(26)](https://www.imo.org/en/KnowledgeCentre/IndexofIMOResolutions/Pages/A-2009-11.aspx) — Code on Alerts and Indicators
-- IEC 62682:2023 — Management of alarm systems for the process industries
+- IEC 62923-1/-2:2018 — Bridge Alert Management (IEC realization of MSC.302(87); the formal alert state model and alert/indicator lists)
+- IEC 62682:2023 — Management of alarm systems for the process industries (source of the borrowed latching concept)
 - [OpenBridge Design System](https://www.openbridge.no/) — Maritime UI design guidelines
 - [Signal K Specification](https://signalk.org/specification/) — Signal K data model and notification schema
 - [signalk-server#1857](https://github.com/SignalK/signalk-server/issues/1857) — Discussion on alert data model and lifecycle

--- a/docs/SK_NOTIFICATIONS_COMPARISON.md
+++ b/docs/SK_NOTIFICATIONS_COMPARISON.md
@@ -23,14 +23,16 @@ Lifecycle state is tracked separately via `AlarmStatus` boolean flags:
 { silenced: boolean, acknowledged: boolean, canSilence: boolean, canAcknowledge: boolean, canClear: boolean }
 ```
 
-The composite state is `(ALARM_STATE, silenced, acknowledged)`, and there is an **implicit state machine** with guard-enforced transitions in the `Alarm` class:
+The composite state is `(ALARM_STATE, silenced, acknowledged)`, and there is an **implicit state machine** with guard-enforced transitions across the `Alarm` and `NotificationManager` classes:
 
 - `silence()` — throws if `!canSilence`, already silenced/acknowledged, or emergency. Sets `silenced = true`, removes `sound` from method.
 - `acknowledge()` — throws if `!canAcknowledge` or already acknowledged. Sets `acknowledged = true`, adjusts method (emergency keeps visual; others get `[]`).
 - `clear()` — throws if `!canClear`. Resets to `state = normal`, `silenced = false`, `acknowledged = false`.
-- `update()` (PR #2560) — when state (severity) changes, resets `silenced = false` and `acknowledged = false` (reactivation behavior).
+- `update()` — when the severity changes, resets `silenced = false` and `acknowledged = false` (reactivation), so a re-fired alarm demands a fresh operator response.
+- Inbound deltas reactivate too: when an external notification transitions from `normal` to an active state, `syncFromNotificationUpdate()` clears `silenced`/`acknowledged`.
+- Returned-to-normal notifications are reaped: a background timer deletes any notification that has stayed `normal` for one cleanup interval (~60 s).
 
-So the Notifications API does enforce transition rules — it's not just flag toggling. But the state machine is not formalized as named lifecycle states with an explicit transition table; it's encoded in guard clauses across the action methods.
+So the Notifications API does enforce transition rules and does manage a lifecycle — it's not just flag toggling. What it lacks is a *formalized* model: there are no named lifecycle states or an explicit transition table, only guard clauses across the action methods.
 
 ### signalk-alert-manager
 
@@ -95,7 +97,7 @@ The Notifications API's use of "state" for severity and "status" for lifecycle i
 |------------|------------------|---------------|
 | 4-state model (A/B/C/D) | Not implemented | Implemented (normal/unacknowledged/acknowledged/rtn-unacknowledged) |
 | Latching alerts | Not supported | Supported |
-| State transitions enforced | No — actions are flag toggles | Yes — invalid transitions rejected |
+| State transitions enforced | Partial — `silence`/`acknowledge`/`clear` enforce guards and throw on invalid transitions, but there is no named-state model | Yes — formal state machine; invalid inputs resolve to no-ops |
 | Shelving/suppression | Not implemented | Not implemented (deferred per spec) |
 
 ### NMEA 2000 (PGN 126983)
@@ -112,6 +114,7 @@ The Notifications API's use of "state" for severity and "status" for lifecycle i
 
 | Feature | Notifications API | alert-manager |
 |---------|------------------|---------------|
+| Identity | UUID per notification; UUID-addressed REST API (`/notifications/{id}`) | UUID per alert; published by origin path (`alerts.{path}`) |
 | Raise via API | Yes (full raise/update, PR #2560) | Yes (via REST API and delta) |
 | Raise via delta | Yes (external notifications) | Yes (primary ingestion path) |
 | Acknowledge | Yes (sets boolean) | Yes (state transition) |
@@ -120,9 +123,9 @@ The Notifications API's use of "state" for severity and "status" for lifecycle i
 | Silence all | Yes | Yes |
 | Acknowledge all | Yes | No (per spec — ack requires individual attention) |
 | Clear | Yes (API-originated only) | Yes (condition-driven, not operator-driven) |
-| Update/escalate | Yes (update, PR #2560) | Yes (automatic W→A escalation) |
+| Update/escalate | Manual only — `update` re-raises and resets ack/silence on severity change; no automatic escalation | Yes (automatic W→A escalation) |
 | MOB alarm | Yes (dedicated endpoint) | No (would be a specific alert definition) |
-| Persistence | No (in-memory only) | Yes (JSON file store, survives restart) |
+| Persistence | No (in-memory only) | Yes (SQLite store, survives restart) |
 | History | No | Yes (event history with configurable retention) |
 | Source liveness | No | Yes (stale detection when source goes offline) |
 | Web UI | No (API only, consumers build their own) | Yes (Lit-based alert panel) |
@@ -157,12 +160,12 @@ Notification actions (PR #2560):
 - AlarmRaiseOptions / AlarmUpdateOptions / AlarmProperties types
 
 **Not implemented:**
-- State machine / lifecycle enforcement
+- Formal named-state lifecycle model (uses severity × status flags with guarded actions instead)
 - Silence timeout
 - Escalation
 - Persistence
 - History
-- Return-to-normal state
+- Return-to-normal *unacknowledged* state (no ack-pending step after a condition clears)
 - Latching
 - Source liveness tracking
 
@@ -174,13 +177,13 @@ Notification actions (PR #2560):
 - Silence with configurable timeout (per priority)
 - Automatic escalation (W→A)
 - Latching alerts
-- Persistence (JSON file store)
+- Persistence (SQLite store)
 - Alert history with retention
 - Source liveness and stale detection
 - REST API (raise, acknowledge, silence, clear, query)
-- Delta publishing (Signal K integration)
+- Alert state published as `alerts.*` Signal K deltas (own model, not `notifications.*`)
 - Lit-based web UI (alert list, detail, banner, history)
-- Notification transformer (alert → Signal K v1 notification format)
+- Notification ingestion (incoming `notifications.*` deltas → managed alerts)
 
 **Not implemented:**
 - N2K export (mapping documented, code not written)
@@ -194,19 +197,19 @@ The two systems operate at different layers:
 
 - **Notifications API** is part of the Signal K server core. It manages the wire format — how notifications appear in deltas, how they're identified, what actions can be taken via HTTP. It's a **transport and action layer**.
 
-- **signalk-alert-manager** is a plugin that implements the **domain logic** — the alert lifecycle state machine, escalation rules, timing constraints, persistence. It consumes and produces Signal K deltas, and includes a `NotificationTransformer` that converts its alert model back into the Signal K notification format for interoperability.
+- **signalk-alert-manager** is a plugin that implements the **domain logic** — the alert lifecycle state machine, escalation rules, timing constraints, persistence. It ingests incoming `notifications.*` deltas (its `NotificationTransformer` maps them to managed alerts) and publishes alert state on its own `alerts.*` paths.
 
-They are complementary, not competing. The Notifications API provides the protocol-level infrastructure; the alert-manager provides the domain-level intelligence. The alert-manager's `NotificationTransformer` already bridges the gap by emitting standard Signal K notifications from its richer alert model.
+They are complementary, not competing. The Notifications API provides the protocol-level infrastructure; the alert-manager provides the domain-level intelligence. The bridge between them is one-way: the alert-manager *ingests* notifications as one alert source, but it does not write back into `notifications.*` — its output lives in a separate `alerts.*` tree.
 
 ## 7. Compatibility Considerations
 
 ### What works today
 
-The alert-manager subscribes to Signal K deltas (including N2K-originated notifications) and maps them into its state machine. It publishes state changes back as Signal K notifications via `NotificationTransformer`. The Notifications API can then process these like any other notification.
+The alert-manager subscribes to Signal K deltas (including N2K-originated notifications) and maps them into its state machine via `NotificationTransformer`. Ingestion is non-destructive — it registers a delta input handler and does not rewrite `notifications.*`. It publishes alert state on its own `alerts.*` paths, which the Notifications API ignores.
 
 ### Potential friction
 
-1. **Dual management**: If both systems process the same notification, they may fight over the `method` array and `status` flags. The Notifications API rewrites `method` on every delta; the alert-manager tracks its own state independently. This is manageable because the alert-manager publishes via `handleMessage` and the Notifications API processes inbound deltas — but the interaction needs care.
+1. **Double handling**: Both systems consume the same inbound `notifications.*` deltas independently — the Notifications API stamps each with an `id`/`status` and re-emits it, while the alert-manager maps it into a managed alert. There is no write conflict (the plugin never writes `notifications.*`; it emits `alerts.*`), but a single device notification then surfaces in two places — under `notifications.*` and under `alerts.*` — and consumers should know which they're reading.
 
 2. **Vocabulary mismatch**: The alert-manager uses `state` for lifecycle and `priority` for severity. The Notifications API uses `state` for severity and `status` for lifecycle flags. Any bridging code must translate carefully.
 

--- a/docs/SK_NOTIFICATIONS_COMPARISON.md
+++ b/docs/SK_NOTIFICATIONS_COMPARISON.md
@@ -36,7 +36,7 @@ So the Notifications API does enforce transition rules and does manage a lifecyc
 
 ### signalk-alert-manager
 
-Uses a formal IEC 62682-based state machine with four lifecycle states orthogonal to priority:
+Uses a formal four-state alert lifecycle (the IEC 62923-1 marine bridge alert management model; equivalently IEC 62682 states A–D) orthogonal to priority:
 
 | State | Condition Active | Acknowledged |
 |-------|-----------------|--------------|
@@ -58,7 +58,7 @@ State transitions are explicit and enforced:
 
 Both systems have a state model, but they differ in what they formalize:
 
-1. **Vocabulary inversion**: The Notifications API uses `state` for severity and `status` for lifecycle. The alert-manager uses `state` for lifecycle and `priority` for severity. The alert-manager aligns with IEC 62682/IMO terminology.
+1. **Vocabulary inversion**: The Notifications API uses `state` for severity and `status` for lifecycle. The alert-manager uses `state` for lifecycle and `priority` for severity. The alert-manager aligns with IMO / IEC 62923 marine terminology.
 
 2. **Lifecycle granularity**: The alert-manager has an explicit rtn-unacknowledged state (condition cleared, ack pending). The Notifications API has no equivalent — when an external source sends `state: normal`, the notification goes directly to normal with no intermediate "you still need to acknowledge this" state.
 
@@ -68,15 +68,15 @@ Both systems have a state model, but they differ in what they formalize:
 
 ## 2. Vocabulary
 
-| Concept | Notifications API | alert-manager | NMEA 2000 | IMO/IEC |
+| Concept | Notifications API | alert-manager | NMEA 2000 | IMO / IEC 62923 |
 |---------|------------------|---------------|-----------|---------|
 | The thing itself | notification / alarm | alert | alert | alert |
 | How bad | `state` (alarm_state) | `priority` | Alert Type | alert category/priority |
-| Lifecycle position | `status` (booleans) | `state` (enum) | Alert State | state (A/B/C/D) |
+| Lifecycle position | `status` (booleans) | `state` (enum) | Alert State | named lifecycle state |
 | Audio suppression | `method` array manipulation | `silenced` boolean | Temporary Silence Status | silence |
 | Operator response | `acknowledged` boolean | `state: acknowledged` | Acknowledge Status | acknowledge |
 
-The Notifications API's use of "state" for severity and "status" for lifecycle is inverted from IMO/IEC usage. The alert-manager aligns with the standards vocabulary.
+The Notifications API's use of "state" for severity and "status" for lifecycle is inverted from IMO / IEC 62923 usage. The alert-manager aligns with the marine standards vocabulary.
 
 ## 3. Standards Compatibility
 
@@ -91,14 +91,16 @@ The Notifications API's use of "state" for severity and "status" for lifecycle i
 | Escalation (W→A) | Not implemented | Yes — configurable timeout, automatic |
 | Emergency cannot be silenced | Yes (enforced) | Yes (shorter silence duration, configurable) |
 
-### IEC 62682
+### IEC 62682 (process industries — borrowed concepts, not a conformance target)
 
-| Requirement | Notifications API | alert-manager |
-|------------|------------------|---------------|
-| 4-state model (A/B/C/D) | Not implemented | Implemented (normal/unacknowledged/acknowledged/rtn-unacknowledged) |
-| Latching alerts | Not supported | Supported |
-| State transitions enforced | Partial — `silence`/`acknowledge`/`clear` enforce guards and throw on invalid transitions, but there is no named-state model | Yes — formal state machine; invalid inputs resolve to no-ops |
-| Shelving/suppression | Not implemented | Not implemented (deferred per spec) |
+IEC 62682 is a process-industry alarm standard. The alert-manager borrows two concepts from it — the return-to-normal-unacknowledged state and latching — each filling a gap the IMO / IEC 62923 marine model leaves. Its process-plant machinery (states E/F/G — shelving, suppressed-by-design, out-of-service — plus rationalization and performance KPIs) is out of scope for recreational use. The comparison below is against those borrowed concepts, not full conformance:
+
+| Concept | Notifications API | alert-manager |
+|---------|------------------|---------------|
+| Return-to-normal unacknowledged | Not modeled | Named state (IEC 62923 implies the behavior; IEC 62682 formalizes it) |
+| Latching | Not supported | Supported (for one-shot events) |
+| State-transition enforcement | Partial — guard-enforced actions, no named-state model | Yes — formal four-state machine |
+| Shelving / suppression (E/F/G) | Not implemented | Out of scope for recreational use (large-plant features) |
 
 ### NMEA 2000 (PGN 126983)
 
@@ -172,7 +174,7 @@ Notification actions (PR #2560):
 ### signalk-alert-manager (plugin)
 
 **Implemented:**
-- Full IEC 62682 state machine (4 states)
+- Full IEC 62923 four-state alert lifecycle
 - Priority levels (4) with distinct behaviors
 - Silence with configurable timeout (per priority)
 - Automatic escalation (W→A)
@@ -188,7 +190,7 @@ Notification actions (PR #2560):
 **Not implemented:**
 - N2K export (mapping documented, code not written)
 - N2K acknowledge-back (PGN 126984 response)
-- Shelving/suppression (IEC 62682 states E/F/G)
+- Shelving / suppression / out-of-service (IEC 62682 states E/F/G — process-plant features, deliberately out of scope)
 - Authorization model (deferred to Signal K auth)
 
 ## 6. Architectural Relationship


### PR DESCRIPTION
## Why

The comparison docs (the README table and `docs/SK_NOTIFICATIONS_COMPARISON.md`) had two problems: factual drift about the current Signal K Notifications API, and standards mis-attribution — crediting the alert lifecycle to IEC 62682 (a process-industry standard, in one place called "maritime") while the marine standards went uncited.

## What

**Factual accuracy** (verified against upstream signalk-server `master` 2.28.0 + the plugin source):
- The Notifications API now has UUIDs, acknowledge/silence, and a guard-enforced lifecycle with reactivation — corrected the README "Not supported"/"None" rows and the doc's self-contradictory verdict rows.
- Fixed plugin-side errors: persistence is **SQLite** (not "JSON file store"); the `NotificationTransformer` ingests `notifications.*` → alerts (it does not emit standard notifications); the plugin publishes its own `alerts.*` tree.
- Added an identity/UUID row; defined the Priority-model row.

**Standards repositioning** (consistent with #102, now merged):
- IMO MSC.302(87) / IEC 62923-1 are primary for the lifecycle; IEC 62682 is named only as the source of the borrowed concepts (return-to-normal-unacknowledged, latching).
- Fixed the README "maritime safety standards (IEC 62682)" conflation; reframed the §3 IEC 62682 table from a conformance scorecard to "borrowed concepts, not a conformance target" with process-plant states (E/F/G) marked out of scope rather than deferred; dropped the A/B/C/D state-letter codes.

Docs-only. Companion to #102 (zero file overlap by design); rebased on `main` after #102 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
