### PR TITLE
Remove the unreachable `app.alertManager` plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Removed
+
+- **BREAKING:** The `app.alertManager` plugin API, its `AlertManagerAPI` exported type, and the `@signalk/server-api` module augmentation that declared it. Signal K server hands every plugin its own copy of the app object, so the property was never visible to any other plugin; the augmentation made calls to it type-check in plugin authors' editors while failing at runtime. Plugins raise and clear alerts by publishing `alerts.*` deltas and use the REST API for acknowledge, silence, and queries.
+
 ## [0.2.0] - 2026-06-30
 
 ### Changed
@@ -29,7 +35,6 @@ Initial release.
 - Source liveness tracking with stale alert detection
 - SQLite persistence for alerts and full audit history (via Node.js 22 `node:sqlite`)
 - REST API for all alert operations
-- Plugin API (`app.alertManager`) for inter-plugin integration
 - Signal K notification interception and automatic transformation to managed alerts
 - Delta publishing for real-time WebSocket updates
 - Web UI with alert list, alert detail view, alert banner, and audio indicators (Lit web components)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
 import { join } from 'path'
 import type { IRouter } from 'express'
 import type { Plugin, ServerAPI } from '@signalk/server-api'
-import type { AlertDefinition, AlertManagerAPI, PluginConfig } from './types.js'
+import type { PluginConfig } from './types.js'
 import { AlertManager, type AlertManagerConfig } from './core/AlertManager.js'
 import { AlertStore } from './store/AlertStore.js'
 import { HistoryStore } from './store/HistoryStore.js'
@@ -23,7 +23,6 @@ export type {
   AlertState,
   Alert,
   AlertDefinition,
-  AlertManagerAPI,
   AlertTransitionResult,
   RaiseAlertRequest,
   AlertFilter,
@@ -192,7 +191,6 @@ export default function createPlugin(app: ServerAPI): AlertManagerPlugin {
   let historyStore: HistoryStore | undefined
   let readyPromise: Promise<void> | undefined
   let uiConfig: UiConfig = { minAudiblePriority: 'warning', enableSimulation: false }
-  const alertTypes = new Map<string, AlertDefinition>()
 
   const plugin: AlertManagerPlugin = {
     id: 'signalk-alert-manager',
@@ -286,21 +284,6 @@ export default function createPlugin(app: ServerAPI): AlertManagerPlugin {
           return
         }
 
-        const api: AlertManagerAPI = {
-          raiseAlert: (params) => mgr.raiseAlert(params),
-          escalateAlert: (alertId, newPriority) => mgr.escalateAlert(alertId, newPriority),
-          clearCondition: (alertId) => mgr.clearCondition(alertId),
-          acknowledgeAlert: (alertId, userId) => mgr.acknowledgeAlert(alertId, userId),
-          silenceAlert: (alertId, durationMs) => mgr.silenceAlert(alertId, durationMs),
-          silenceAll: () => mgr.silenceAll(),
-          getAlerts: (filter) => mgr.getAlerts(filter),
-          getAlert: (id) => mgr.getAlert(id),
-          registerAlertType: (definition) => {
-            alertTypes.set(definition.alertType, definition)
-          }
-        }
-        app.alertManager = api
-
         app.setPluginStatus('Running')
       })()
 
@@ -324,8 +307,6 @@ export default function createPlugin(app: ServerAPI): AlertManagerPlugin {
       alertDeltaTransformer?.stop()
       publisher?.stop()
       manager?.stop()
-      delete app.alertManager
-      alertTypes.clear()
 
       alertStore?.close().catch(() => undefined)
       historyStore?.close().catch(() => undefined)

--- a/src/types.ts
+++ b/src/types.ts
@@ -315,11 +315,11 @@ export interface PluginConfig {
 }
 
 // =============================================================================
-// Plugin API Types
+// State Transition Types
 // =============================================================================
 
 /**
- * Result of a state transition, as returned by the plugin API.
+ * Result of an alert state transition.
  */
 export interface AlertTransitionResult {
   /** The updated alert, or null if the alert was cleared */
@@ -328,33 +328,6 @@ export interface AlertTransitionResult {
   cleared: boolean
   /** The state before the transition */
   previousState: AlertState
-}
-
-/**
- * Public API exposed on app.alertManager for other Signal K plugins.
- */
-export interface AlertManagerAPI {
-  raiseAlert(
-    params: RaiseAlertRequest & { $source: string; source?: Record<string, unknown> }
-  ): Promise<Alert>
-  escalateAlert(alertId: string, newPriority: AlertPriority): Promise<Alert>
-  clearCondition(alertId: string): Promise<AlertTransitionResult>
-  acknowledgeAlert(alertId: string, userId?: string): Promise<AlertTransitionResult>
-  silenceAlert(alertId: string, durationMs?: number): Promise<Alert>
-  silenceAll(): Promise<void>
-  getAlerts(filter?: AlertFilter): Alert[]
-  getAlert(id: string): Alert | null
-  registerAlertType(definition: AlertDefinition): void
-}
-
-// =============================================================================
-// Module Augmentation
-// =============================================================================
-
-declare module '@signalk/server-api' {
-  interface ServerAPI {
-    alertManager?: AlertManagerAPI
-  }
 }
 
 // =============================================================================

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -172,9 +172,8 @@ describe('Signal K Plugin', () => {
       // Wait for the async chain to settle
       await new Promise((r) => setTimeout(r, 100))
 
-      // alertManager should not be set since we stopped during init
-      const appWithApi = mockApi as unknown as ServerAPI
-      expect(appWithApi.alertManager).toBeUndefined()
+      // Initialization aborted, so the plugin never reached the running state
+      expect(mockApi.getPluginStatus()).not.toBe('Running')
     })
 
     it('should guard against double start', async () => {
@@ -189,8 +188,18 @@ describe('Signal K Plugin', () => {
       })
 
       // Should still be functional
-      const api = (mockApi as unknown as ServerAPI).alertManager
-      expect(api).toBeDefined()
+      expect(mockApi.getPluginStatus()).toBe('Running')
+    })
+
+    it('should not attach a cross-plugin API to the app object', async () => {
+      plugin.start({}, () => {
+        /* restart callback */
+      })
+      await plugin.whenReady?.()
+
+      // Signal K server gives each plugin its own copy of the app object, so
+      // properties attached here are invisible to every other plugin
+      expect(Object.hasOwn(mockApi, 'alertManager')).toBe(false)
     })
   })
 


### PR DESCRIPTION
signalk-server gives every plugin its own shallow copy of the server app object (`_.assign({}, app, {...})` in `interfaces/plugins.ts`), so anything a plugin attaches to that copy is invisible to every other plugin. The `app.alertManager = api` assignment in `start()` has therefore never done anything for anyone but this plugin, on any server version. #104 has the full trace.

Dead code alone would be cheap to leave. The `declare module '@signalk/server-api'` augmentation in `types.ts` was not: it added `alertManager?: AlertManagerAPI` to the server's own `ServerAPI` interface, so a third-party plugin author who installed our types got `app.alertManager.raiseAlert(...)` to type-check in their editor, a green build, and `undefined` at runtime. Deleting the augmentation converts that silent runtime failure into an immediate compile error, which is the outcome we want for anyone still holding the false assumption.

So this removes the API object, the `stop()` teardown that unset it, the alert-type registry that only the API could write to, the `AlertManagerAPI` type export, and the module augmentation. A regression test pins the intent — after a completed start, the app object carries no `alertManager` property — so nobody reintroduces the pattern by reflex. Two existing lifecycle tests had been using `app.alertManager` as a stand-in for "did the plugin finish starting"; they now assert on plugin status directly, which is what they meant all along.

The CHANGELOG's 0.1.0 entry claimed the plugin API as a shipped feature. It is deleted rather than amended: it describes something that never worked, so it does not belong in the record of what that release delivered. A new `[Unreleased] / Removed` entry explains the removal and points integrators at the paths that do work.

Docs are handled separately by #106 (@dirkwa), which rewrites the README, ARCHITECTURE, SPEC and comparison prose. This PR deliberately stays off those files so the two can land in either order without conflicting — note that README's exported-types list still mentions `AlertManagerAPI` until #106 merges.

Closes #104.
